### PR TITLE
fix executor import in runner danger

### DIFF
--- a/source/danger/danger_runner.ts
+++ b/source/danger/danger_runner.ts
@@ -7,7 +7,7 @@ import { PullRequestJSON } from "../github/types/pull_request"
 
 import { getCISourceForEnv } from "danger/distribution/ci_source/ci_source"
 import { GitHub } from "danger/distribution/platforms/GitHub"
-import Executor from "danger/distribution/runner/Executor"
+import { Executor } from "danger/distribution/runner/Executor"
 
 import { writeFileSync } from "fs"
 import { tmpdir } from "os"


### PR DESCRIPTION
I use to get the following error:
```
Type Error Executor is not a function
```
I guess the import was just wrong