### PR TITLE
Also support JSON-based settings instead of postgres

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,5 @@ pids
 node_modules
 .npm
 *.dat
-config/default.json
-config/staging.now.env
 out
 .env

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "author": "Orta",
   "license": "MIT",
   "dependencies": {
-    "@types/config": "^0.0.32",
     "@types/debug": "^0.0.29",
     "@types/ejs": "^2.3.33",
     "@types/express": "^4.0.34",
@@ -37,7 +36,6 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-stage-3": "^6.22.0",
     "body-parser": "^1.15.2",
-    "config": "^1.20.4",
     "danger": "^0.15.0",
     "dotenv": "^4.0.0",
     "ejs": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ts-jest": "^19.0.0",
     "ts-node": "^3.0.2",
     "tslint": "^4.5.1",
-    "typescript": "^2.2.2",
+    "typescript": "^2.3.2",
     "typings": "^2.0.0",
     "winston": "^2.3.1",
     "winston-papertrail": "^1.0.4"

--- a/source/api/fetch.ts
+++ b/source/api/fetch.ts
@@ -1,10 +1,9 @@
-const config = require("config")  // tslint:disable-line
 import * as node_fetch from "node-fetch"
 
 export default function fetch(url: string | node_fetch.Request, init?: node_fetch.RequestInit):
   Promise<node_fetch.Response> {
 
-  if (config.has("LOG_FETCH_REQUESTS") && init) {
+  if (process.env.LOG_FETCH_REQUESTS && init) {
     const output = ["curl", "-i"]
     if (init.method) {
       output.push(`-X ${init.method}`)

--- a/source/api/github.ts
+++ b/source/api/github.ts
@@ -5,7 +5,7 @@ import * as fs from "fs"
 import * as os from "os"
 
 import * as jwt from "jsonwebtoken"
-import { getInstallation, GitHubInstallation } from "../db"
+import { GitHubInstallation } from "../db"
 import winston from "../logger"
 import originalFetch from "./fetch"
 

--- a/source/danger/_tests/_danger_runner.test.ts
+++ b/source/danger/_tests/_danger_runner.test.ts
@@ -53,7 +53,15 @@ describe("evaling", () => {
       })
   })
 
-  // I wonder if the babel setup isn't quite right yet
+  it("highlights some of the security measures", async () => {
+      const executor = executorForInstallation(platform)
+      const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_insecure.ts`, executor)
+      expect(results.markdowns).toEqual([
+        "`Object.keys(process.env).length` is 0",
+      ])
+  })
+
+  // I wonder if the babel setup isn't quite right yet for this test
   it.skip("runs a JS dangerfile with fixtured data", async () => {
       const executor = executorForInstallation(platform)
       // The executor will return results etc in the next release

--- a/source/danger/_tests/fixtures/dangerfile_insecure.ts
+++ b/source/danger/_tests/fixtures/dangerfile_insecure.ts
@@ -1,0 +1,1 @@
+markdown("`Object.keys(process.env).length` is " + Object.keys(process.env).length)

--- a/source/danger/danger_run.ts
+++ b/source/danger/danger_run.ts
@@ -8,7 +8,7 @@ import { DangerfileReferenceString, RunnerRuleset } from "../db"
 export enum dsl {
   /** What, for years, has been the "Danger DSL" */
   pr,
-  /** Take whatever triggered this run and use that as the github. DSL */
+  /** Take whatever JSON triggered this run and use that as the `github.` DSL */
   import,
 }
 

--- a/source/danger/danger_runner.ts
+++ b/source/danger/danger_runner.ts
@@ -1,6 +1,3 @@
-/* tslint:disable: no-var-requires */
-const config = require("config")
-
 import { Platform } from "danger/distribution/platforms/platform"
 import winston from "../logger"
 
@@ -36,6 +33,7 @@ export async function  runDangerAgainstInstallation(contents: string, path: stri
 
   const exec = await executorForInstallation(platform)
 
+  // TODO: Replace this sync call
   const localDangerfile = tmpdir() + "/" + path
   writeFileSync(localDangerfile, contents)
 
@@ -85,15 +83,9 @@ export function executorForInstallation(platform: Platform) {
     supportedPlatforms: [],
   }
 
-  // The executor config should deprecate the need for this ideally
-
-  if (config.has("LOG_FETCH_REQUESTS")) {
-    global["verbose"] = true // tslint:disable-line
-  }
-
   const execConfig = {
     stdoutOnly: false,
-    verbose: config.has("LOG_FETCH_REQUESTS"),
+    verbose: process.env.LOG_FETCH_REQUESTS,
   }
 
   // Source can be removed in the next release of Danger

--- a/source/db/_tests/__snapshots__/_json.test.ts.snap
+++ b/source/db/_tests/__snapshots__/_json.test.ts.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`makes the right calls to GitHub gets repo rules correct 1`] = `
+Object {
+  "UUID": 123123123,
+  "fullName": "orta/ORStackView",
+  "id": 111,
+  "installationID": 1,
+  "rules": Object {
+    "issue.created": "orta/peril@lock_issues.ts",
+  },
+}
+`;
+
+exports[`makes the right calls to GitHub with a legit stubbed JSON file 1`] = `
+Object {
+  "id": 1,
+  "repos": Object {
+    "orta/ORStackView": Object {
+      "issue.created": "orta/peril@lock_issues.ts",
+    },
+  },
+  "rules": Object {
+    "issue": "orta/peril@issue.ts",
+    "pull_request": "orta/peril@pr.ts",
+  },
+  "settings": Object {
+    "onlyForOrgMembers": false,
+  },
+}
+`;

--- a/source/db/_tests/__snapshots__/_json.test.ts.snap
+++ b/source/db/_tests/__snapshots__/_json.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`makes the right calls to GitHub gets repo rules correct 1`] = `
 Object {
-  "UUID": 123123123,
   "fullName": "orta/ORStackView",
   "id": 111,
   "installationID": 1,

--- a/source/db/_tests/_json.test.ts
+++ b/source/db/_tests/_json.test.ts
@@ -1,0 +1,53 @@
+const legitSettings = `{
+  "id": 1,
+  "settings": {
+    "onlyForOrgMembers": false
+  },
+  "rules": {
+   "pull_request": "orta/peril@pr.ts",
+   "issue": "orta/peril@issue.ts"
+  },
+  "repos" : {
+    "orta/ORStackView": {
+      "issue.created": "orta/peril@lock_issues.ts"
+    }
+  }
+}`
+
+const contentsMock = jest.fn((token, path) => {
+  console.log(path)
+  if (path === "orta/peril") { return Promise.resolve(legitSettings) }
+  if (path === "orta/other") { return Promise.resolve("") }
+})
+
+jest.mock("../../github/lib/github_helpers", () =>  ({ getGitHubFileContents: contentsMock }))
+
+import { DatabaseAdaptor } from "../index"
+import jsonDB from "../json"
+
+describe("makes the right calls to GitHub", () => {
+  let db: DatabaseAdaptor = null as any
+
+  beforeEach(async () => {
+    db = jsonDB("orta/peril@settings.json")
+    await db.setup()
+  })
+
+  it("with a legit stubbed JSON file", async () => {
+    const org = await db.getInstallation(1)
+    expect(org).toMatchSnapshot()
+  })
+
+  it("gets repo rules correct", async () => {
+    const repo = await db.getRepo(1, "orta/ORStackView")
+    expect(repo).toMatchSnapshot()
+  })
+})
+
+// need a unhandled rejection from promises?
+it.skip("Raises with a bad URL",  () => {
+  const db = jsonDB("orta/other@settings.json")
+  expect(async () => {
+    await db.setup()
+  }).toThrowErrorMatchingSnapshot()
+})

--- a/source/db/_tests/_json.test.ts
+++ b/source/db/_tests/_json.test.ts
@@ -15,7 +15,6 @@ const legitSettings = `{
 }`
 
 const contentsMock = jest.fn((token, path) => {
-  console.log(path)
   if (path === "orta/peril") { return Promise.resolve(legitSettings) }
   if (path === "orta/other") { return Promise.resolve("") }
 })

--- a/source/db/index.ts
+++ b/source/db/index.ts
@@ -3,6 +3,7 @@ import { DATABASE_JSON_FILE, DATABASE_URL } from "../globals"
 import winston from "../logger"
 import { GitHubUser } from "./types"
 
+import jsonDB from "./json"
 import postgres from "./postgres"
 
 /**
@@ -78,7 +79,9 @@ let exposedDB: DatabaseAdaptor = null as any
 if (DATABASE_URL) {
   exposedDB = postgres
 } else {
-  // exposedDB = json
+  exposedDB = jsonDB(DATABASE_JSON_FILE)
 }
+
+exposedDB.setup()
 
 export default exposedDB

--- a/source/db/index.ts
+++ b/source/db/index.ts
@@ -1,12 +1,9 @@
-import { DATABASE_URL } from "../globals"
+import { getGitHubFileContents } from "../github/lib/github_helpers"
+import { DATABASE_JSON_FILE, DATABASE_URL } from "../globals"
 import winston from "../logger"
 import { GitHubUser } from "./types"
 
-// Docs: https://github.com/vitaly-t/pg-promise
-// Examples: https://github.com/vitaly-t/pg-promise/wiki/Learn-by-Example
-
-import * as pg from "pg-promise"
-let db = pg()(DATABASE_URL)
+import postgres from "./postgres"
 
 /**
  * Should look like one of the following:
@@ -45,17 +42,6 @@ export interface GitHubInstallation {
   rules: RunnerRuleset
 }
 
-/** Logs */
-const info = (message: string) => { winston.info(`[db] - ${message}`) }
-
-/** Saves an Integration */
-export async function saveInstallation(installation: GitHubInstallation) {
-  info(`Saving installation with id: ${installation.id}`)
-  return db.one(
-    "insert into installations(id, settings, rules) values($1, $2, $3) returning *",
-    [installation.id, JSON.stringify(installation.settings), JSON.stringify(installation.rules)])
-}
-
 export type RunnerRuleset = { [name: string]: DangerfileReferenceString }
 
 export interface GithubRepo {
@@ -69,36 +55,30 @@ export interface GithubRepo {
   rules: RunnerRuleset
 }
 
-/** Saves a repo */
-export async function saveGitHubRepo(repo: GithubRepo) {
-  info(`Saving repo with slug: ${repo.fullName}`)
-  return db.one(
-    "insert into github_repos(id, installations_id, full_name, rules) values($1, $2, $3, $4) returning *",
-    [repo.id, repo.installationID, repo.fullName, JSON.stringify(repo.rules)])
+export interface DatabaseAdaptor {
+  /** A once per server start setup function */
+  setup: () => Promise<void>
+
+  /** Gets an integrations settings */
+  getInstallation: (installationID: number) => Promise<GitHubInstallation | null>
+  /** Saves an Integration */
+  saveInstallation: (installation: GitHubInstallation) => Promise<void>
+  /** Deletes the operation */
+  deleteInstallation: (installationID: number) => Promise<void>
+
+  /** Gets an optional repo out of the installation settings */
+  getRepo: (installationID: number, repoName: string) => Promise<GithubRepo | null>
+  /** Saves a Repo */
+  saveGitHubRepo: (repo: GithubRepo) => Promise<void>
+  /** Deletes a repo from the  */
+  deleteRepo: (installationID: number, repoName: string) => Promise<void>
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/** Gets an Integration */
-export async function getInstallation(installationID: number): Promise<GitHubInstallation | null> {
-  return db.one("select * from installations where id=$1", [installationID])
+let exposedDB: DatabaseAdaptor = null as any
+if (DATABASE_URL) {
+  exposedDB = postgres
+} else {
+  // exposedDB = json
 }
 
-/** Deletes an Integration */
-export async function deleteInstallation(installationID: number): Promise<GitHubInstallation> {
-  return db.one("select * from installations where id=$1", [installationID])
-}
-
-/** Gets a Github repo from the DB */
-export async function getRepo(installationID: number, repoName: string): Promise<GithubRepo | null> {
-  const results = await db.any(
-    "select * from github_repos where installations_id=$1 and full_name=$2",
-    [installationID, repoName])
-  return results.length === 0 ? null : results[0]
-}
-/** Deletes a Github repo from the DB */
-export async function deleteRepo(installationID: number, repoName: string): Promise<GithubRepo> {
-  info(`Deleting github repo ${repoName}`)
-  return db.one("delete from github_repos where installations_id=$1 and full_name=$2", [installationID, repoName])
-}
+export default exposedDB

--- a/source/db/json.ts
+++ b/source/db/json.ts
@@ -1,0 +1,57 @@
+import { getGitHubFileContents } from "../github/lib/github_helpers"
+import { DATABASE_JSON_FILE, DATABASE_URL } from "../globals"
+import winston from "../logger"
+import { DatabaseAdaptor, GitHubInstallation, GithubRepo } from "./index"
+import { GitHubUser } from "./types"
+
+// Effectively you need to have a JSON file that looks like a GitHubInstallation,
+// but also have a `repos` array of GitHUbRepo -so you cna do per repo rules in there.
+
+/** Logs */
+const info = (message: string) => { winston.info(`[db] - ${message}`) }
+
+let org: GitHubInstallation = null as any
+
+const database: DatabaseAdaptor = {
+
+  setup: async () => {
+      const repo = DATABASE_JSON_FILE.split("@")[0]
+      const path = DATABASE_JSON_FILE.split("@")[1]
+      const file = await getGitHubFileContents("", repo, path, null)
+      org = JSON.parse(file)
+  },
+
+  /** Saves an Integration */
+   saveInstallation: async (installation: GitHubInstallation) => {
+    info(`Skipping saving installation due to no db: ${installation.id}`)
+  },
+
+  /** Saves a repo */
+ saveGitHubRepo: async (repo: GithubRepo) => {
+    info(`Skipping saving github repo with slug: ${repo.fullName} due to no db`)
+  },
+
+  /** Gets an Integration */
+  getInstallation: async (installationID: number): Promise<GitHubInstallation | null> => {
+    return org
+  },
+
+  /** Deletes an Integration */
+  deleteInstallation: async (installationID: number) => {
+    info(`Skipping saving github repo with slug.`)
+  },
+
+  /** Gets a Github repo from the DB */
+  getRepo: async (installationID: number, repoName: string): Promise<GithubRepo | null> => {
+    // Type this?
+    const repos: GithubRepo[] = (org as any).repos
+    return repos.find((r) => r.fullName === repoName) || null
+  },
+
+  /** Deletes a Github repo from the DB */
+  deleteRepo: async (installationID: number, repoName: string) => {
+    info(`Skipping deleting github repo ${repoName} due to no db`)
+  },
+}
+
+export default database

--- a/source/db/json.ts
+++ b/source/db/json.ts
@@ -76,13 +76,14 @@ const jsonDatabase = (dangerFilePath: DangerfileReferenceString) : DatabaseAdapt
     // Type this?
     const repos = (org as any).repos
     if (!repos[repoName]) { return null }
-    return {
-      UUID: 123123123,
+
+    const repo: GithubRepo = {
       fullName: repoName,
-      id: 111,
-      installationID: 1,
+      id: 111, // Should I care?
+      installationID: 1, // Should I care?
       rules: repos[repoName],
     }
+    return repo
   },
 
   /** Deletes a Github repo from the DB */

--- a/source/db/json.ts
+++ b/source/db/json.ts
@@ -1,28 +1,58 @@
+import {getTemporaryAccessTokenForInstallation} from "../api/github"
 import { getGitHubFileContents } from "../github/lib/github_helpers"
-import { DATABASE_JSON_FILE, DATABASE_URL } from "../globals"
+import { PERIL_ORG_INSTALLATION_ID} from "../globals"
 import winston from "../logger"
-import { DatabaseAdaptor, GitHubInstallation, GithubRepo } from "./index"
+import { DangerfileReferenceString, DatabaseAdaptor, GitHubInstallation, GithubRepo } from "./index"
 import { GitHubUser } from "./types"
 
 // Effectively you need to have a JSON file that looks like a GitHubInstallation,
-// but also have a `repos` array of GitHUbRepo -so you cna do per repo rules in there.
+// but also have a `repos` array of GitHUbRepo -so you can do per repo rules in there.
+
+/*
+For example:
+
+{
+  "id": [your_installation_id], // could be optional?
+  "settings": {
+    "onlyForOrgMembers": false
+  },
+  "rules": {
+   "pull_request": "orta/peril@pr.ts",
+   "issue": "orta/peril@issue.ts"
+  },
+  "repos" : {
+    "orta/ORStackView": {
+      "issue.created": "orta/peril@lock_issues.ts"
+    }
+  }
+}
+*/
 
 /** Logs */
 const info = (message: string) => { winston.info(`[db] - ${message}`) }
 
 let org: GitHubInstallation = null as any
 
-const database: DatabaseAdaptor = {
+const jsonDatabase = (dangerFilePath: DangerfileReferenceString) : DatabaseAdaptor => ({
 
   setup: async () => {
-      const repo = DATABASE_JSON_FILE.split("@")[0]
-      const path = DATABASE_JSON_FILE.split("@")[1]
-      const file = await getGitHubFileContents("", repo, path, null)
+      const repo = dangerFilePath.split("@")[0]
+      const path = dangerFilePath.split("@")[1]
+      // Try see if we can pull it without an access token
+      let file = await getGitHubFileContents(null, repo, path, null)
+      // Might be private, in this case you have to have set up PERIL_ORG_INSTALLATION_ID
+      if (file === "") {
+        if (!PERIL_ORG_INSTALLATION_ID) { throwNoPerilInstallationID() }
+        const token = await getTemporaryAccessTokenForInstallation(PERIL_ORG_INSTALLATION_ID)
+        file = await getGitHubFileContents(token, repo, path, null)
+      }
+
+      if (file === "") { throwNoJSONFileFound(dangerFilePath) }
       org = JSON.parse(file)
   },
 
   /** Saves an Integration */
-   saveInstallation: async (installation: GitHubInstallation) => {
+  saveInstallation: async (installation: GitHubInstallation) => {
     info(`Skipping saving installation due to no db: ${installation.id}`)
   },
 
@@ -44,14 +74,41 @@ const database: DatabaseAdaptor = {
   /** Gets a Github repo from the DB */
   getRepo: async (installationID: number, repoName: string): Promise<GithubRepo | null> => {
     // Type this?
-    const repos: GithubRepo[] = (org as any).repos
-    return repos.find((r) => r.fullName === repoName) || null
+    const repos = (org as any).repos
+    if (!repos[repoName]) { return null }
+    return {
+      UUID: 123123123,
+      fullName: repoName,
+      id: 111,
+      installationID: 1,
+      rules: repos[repoName],
+    }
   },
 
   /** Deletes a Github repo from the DB */
   deleteRepo: async (installationID: number, repoName: string) => {
     info(`Skipping deleting github repo ${repoName} due to no db`)
   },
+})
+
+export default jsonDatabase
+
+// Some error handling.
+
+const throwNoPerilInstallationID = () => {
+    /* tslint:disable: max-line-length */
+  const msg = "Sorry, if you have a Peril JSON setttings file in a private repo, you will need an installation ID for your integration."
+  const subtitle = "You can find this inside the integration_installation event sent when you installed the integration into your org."
+  const action = `Set this as "PERIL_ORG_INSTALLATION_ID" in your ENV vars.`
+  throw new Error([msg, subtitle, action].join(" "))
+  /* tslint:enable: max-line-length */
 }
 
-export default database
+const throwNoJSONFileFound = (dangerFilePath: DangerfileReferenceString) => {
+  /* tslint:disable: max-line-length */
+  const msg = "Could not find find a JSON file for Peril settings."
+  const subtitle = `It's likely that Peril cannot connect to ${dangerFilePath}, check the logs for more info above here.`
+  const action = `You'll probably need to make changes to your  "DATABASE_JSON_FILE" in your ENV vars.`
+  throw new Error([msg, subtitle, action].join(" "))
+  /* tslint:enable: max-line-length */
+}

--- a/source/db/postgres.ts
+++ b/source/db/postgres.ts
@@ -10,11 +10,8 @@ import { GitHubUser } from "./types"
 import * as pg from "pg-promise"
 
 let db: pg.IDatabase<{}>
-//
 /** Logs */
 const info = (message: string) => { winston.info(`[db] - ${message}`) }
-
-let singleInstallationModeInstallation: GitHubInstallation = null as any
 
 const database: DatabaseAdaptor = {
   setup: async () => {

--- a/source/db/postgres.ts
+++ b/source/db/postgres.ts
@@ -1,0 +1,65 @@
+import { getGitHubFileContents } from "../github/lib/github_helpers"
+import { DATABASE_JSON_FILE, DATABASE_URL } from "../globals"
+import winston from "../logger"
+import { DatabaseAdaptor, GitHubInstallation, GithubRepo } from "./index"
+import { GitHubUser } from "./types"
+
+// Docs: https://github.com/vitaly-t/pg-promise
+// Examples: https://github.com/vitaly-t/pg-promise/wiki/Learn-by-Example
+
+import * as pg from "pg-promise"
+
+let db: pg.IDatabase<{}>
+//
+/** Logs */
+const info = (message: string) => { winston.info(`[db] - ${message}`) }
+
+let singleInstallationModeInstallation: GitHubInstallation = null as any
+
+const database: DatabaseAdaptor = {
+  setup: async () => {
+    db = pg()(DATABASE_URL)
+  },
+
+  /** Saves an Integration */
+   saveInstallation: async (installation: GitHubInstallation) => {
+    info(`Saving installation with id: ${installation.id}`)
+    return db.one(
+      "insert into installations(id, settings, rules) values($1, $2, $3) returning *",
+      [installation.id, JSON.stringify(installation.settings), JSON.stringify(installation.rules)])
+  },
+
+  /** Saves a repo */
+ saveGitHubRepo: async (repo: GithubRepo) => {
+    info(`Saving repo with slug: ${repo.fullName}`)
+    return db.one(
+      "insert into github_repos(id, installations_id, full_name, rules) values($1, $2, $3, $4) returning *",
+      [repo.id, repo.installationID, repo.fullName, JSON.stringify(repo.rules)])
+  },
+
+  /** Gets an Integration */
+  getInstallation: async (installationID: number): Promise<GitHubInstallation | null> => {
+      return db.one("select * from installations where id=$1", [installationID])
+  },
+
+  /** Deletes an Integration */
+  deleteInstallation: (installationID: number) => {
+    return db.one("select * from installations where id=$1", [installationID])
+  },
+
+  /** Gets a Github repo from the DB */
+  getRepo: async (installationID: number, repoName: string): Promise<GithubRepo | null> => {
+    const results = await db.any(
+      "select * from github_repos where installations_id=$1 and full_name=$2",
+      [installationID, repoName])
+    return results.length === 0 ? null : results[0]
+  },
+
+  /** Deletes a Github repo from the DB */
+  deleteRepo: (installationID: number, repoName: string) => {
+    info(`Deleting github repo ${repoName}`)
+    return db.one("delete from github_repos where installations_id=$1 and full_name=$2", [installationID, repoName])
+  },
+}
+
+export default database

--- a/source/github/events/_tests/_github_runner-setup.test.ts
+++ b/source/github/events/_tests/_github_runner-setup.test.ts
@@ -1,0 +1,44 @@
+const getRepoFake = () => Promise.resolve({ fake: true })
+jest.mock("../../../db", () => ({ default: { getRepo: getRepoFake } }))
+
+import { readFileSync } from "fs"
+import { resolve } from "path"
+import { setupForRequest } from "../github_runner"
+
+/** Returns JSON from the fixtured dir */
+const requestWithFixturedJSON = (name: string): any => {
+  const path = resolve(__dirname, "fixtures", `${name}.json`)
+  return { body: JSON.parse(readFileSync(path, "utf8")) }
+}
+
+describe("makes the right settings for", () => {
+  it("a pull_request_opened event", async () => {
+    const pr = requestWithFixturedJSON("pull_request_opened")
+    const settings = await setupForRequest(pr)
+
+    expect(settings).toEqual({
+      commentableID: 2,
+      hasRelatedCommentable: true,
+      isRepoEvent: true,
+      isTriggeredByUser: true,
+      repo: { fake: true },
+      repoName: "danger/peril",
+      triggeredByUsername: "orta",
+    })
+  })
+
+  it("an integration_installation_created event", async () => {
+    const pr = requestWithFixturedJSON("integration_installation_created")
+    const settings = await setupForRequest(pr)
+
+    expect(settings).toEqual({
+      commentableID: null,
+      hasRelatedCommentable: false,
+      isRepoEvent: false,
+      isTriggeredByUser: true,
+      repo: null,
+      repoName: false,
+      triggeredByUsername: "orta",
+    })
+  })
+})

--- a/source/github/events/create_installation.ts
+++ b/source/github/events/create_installation.ts
@@ -3,7 +3,7 @@ import * as express from "express"
 import { Installation } from "../events/types/integration_installation_created.types"
 
 import { requestAccessTokenForInstallation } from "../../api/github"
-import { GitHubInstallation, saveInstallation } from "../../db"
+import db, { GitHubInstallation } from "../../db"
 
 export async function createInstallation(installationJSON: Installation, req: express.Request, res: express.Response) {
 
@@ -19,5 +19,5 @@ export async function createInstallation(installationJSON: Installation, req: ex
   // Default to no runnerRules
 
   res.status(200).send("Creating new installation.")
-  await saveInstallation(installation)
+  await db.saveInstallation(installation)
 }

--- a/source/github/events/create_installation.ts
+++ b/source/github/events/create_installation.ts
@@ -16,6 +16,7 @@ export async function createInstallation(installationJSON: Installation, req: ex
       onlyForOrgMembers: true,
     },
   }
+
   // Default to no runnerRules
 
   res.status(200).send("Creating new installation.")

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -17,9 +17,8 @@ import { getGitHubFileContents, isUserInOrg } from "../lib/github_helpers"
  * So, this function has a bunch of responsibilities.
  *
  *  - Validating there is an installation ref in the db
- *  - Getting (potential) repo information
  *  - Generating runs for an installation, could be up to two (org + repo) per integration event
- *  - Going frm a run to executing Danger for that run
+ *  - Going from a run to executing Danger for that run
  *  - Handling the varients in a Danger run
  *
  *    - Event is org based (no repo, DSL is event JSON)
@@ -27,7 +26,6 @@ import { getGitHubFileContents, isUserInOrg } from "../lib/github_helpers"
  *    - Event is PR based (has a repo + issue, can comment, gets normal DangerDSL)
  *    - Event is issue based (has a repo + issue, can comment, gets event DSL )
  *
- *  - Merging multiple results into one
  *  - Passing back the feedback results, if we can
  *
  * As you can imagine, this does indeed make it ripe for a good refactoring in the future.
@@ -35,6 +33,24 @@ import { getGitHubFileContents, isUserInOrg } from "../lib/github_helpers"
 
 /** Logs */
 const log = (message: string) => { winston.info(`[runner] - ${message}`) }
+
+export const setupForRequest = async (req: express.Request) => {
+  const isRepoEvent = !!req.body.repository
+  const repoName = isRepoEvent && req.body.repository.full_name
+  const installationID = req.body.installation.id as number
+  const isTriggeredByUser = !!req.body.sender
+  const hasRelatedCommentable = getIssueNumber(req.body) !== null
+
+  return {
+    commentableID: hasRelatedCommentable ? getIssueNumber(req.body) : null,
+    isRepoEvent,
+    isTriggeredByUser,
+    repo: isRepoEvent ? await db.getRepo(installationID, repoName) : null,
+    repoName,
+    triggeredByUsername: isTriggeredByUser ? req.body.sender.login : null,
+    hasRelatedCommentable,
+  }
+}
 
 export async function githubDangerRunner(event: string, req: express.Request, res: express.Response, next: any) {
   const action = req.body.action as string | null
@@ -46,20 +62,16 @@ export async function githubDangerRunner(event: string, req: express.Request, re
     return
   }
 
-  // The repo could definitely be null, for example: Org User Added
-  // So, we need to assume from here on, that this data is not always available
-  const fullRepoName = req.body.repository && req.body.repository.full_name as string | null
-  let repo = null as GithubRepo | null
-  if (fullRepoName) { repo = await db.getRepo(installationID, fullRepoName) }
-  const runRepo = repo && repo.fullName || fullRepoName
+  const settings = await setupForRequest(req)
 
-  if (!runRepo) {
+  // TODO: Why did I make this call before?
+  if (!settings.isRepoEvent) {
     res.status(404).send(`WIP - not built out support for non-repo related events - sorry`)
     return
   }
 
   const installationRun = dangerRunForRules(event, action, installation.rules)
-  const repoRun = dangerRunForRules(event, action, repo && repo.rules)
+  const repoRun = dangerRunForRules(event, action, settings.repo && settings.repo.rules)
   const runs = [installationRun, repoRun].filter((r) => !!r) as DangerRun[]
 
   // We got no runs ( so there were no rules that correspond to the event)
@@ -69,39 +81,36 @@ export async function githubDangerRunner(event: string, req: express.Request, re
     return
   }
 
+  log(`Event Settings: ${JSON.stringify(settings, null, " ")}`)
   const token = await getTemporaryAccessTokenForInstallation(installation)
 
   const allResults = [] as DangerResults[]
   for (const run of runs) {
     log(`Running: ${JSON.stringify(run, null, " ")}`)
 
-    const useFullDangerDSL = run.dslType === dsl.pr
+    const isPR = run.dslType === dsl.pr
     const supportGithubCommentAPIs = run.feedback === feedback.commentable
 
-    log(`Use fullDSL: ${useFullDangerDSL}`)
+    log(`Use fullDSL: ${isPR}`)
     log(`supportGithubCommentAPIs: ${supportGithubCommentAPIs}`)
-    log(`runRepo: ${runRepo}`)
 
     // Do we need an authenticated Danger GitHubAPI instance so we
     // can leave feedback on an issue?
     let githubAPI = null as GitHubAPI | null
-    if (supportGithubCommentAPIs && runRepo) {
-      const issue = getIssueNumber(req.body)
-      // const repoSlug = getRepoSlug(req.body)
-      // TODO: An org could refer to a dangerfile that's not in the current repo
-      githubAPI = githubAPIForCommentable(run, token, runRepo, issue)
-      log("Got GitHub API")
+    if (supportGithubCommentAPIs && settings.commentableID && settings.repo) {
+      githubAPI = githubAPIForCommentable(run, token, settings.repo.fullName, settings.commentableID)
+      log("Got a GitHub API")
     }
 
     // Are we being extra paranoid about running Dangerfiles?
-    const triggeredByUser = req.body.sender as any | null
-    if (triggeredByUser && githubAPI && runRepo && installation && installation.settings.onlyForOrgMembers) {
+    // Ideally this can move to detect if the PR changed the Dangerfile also
+    const onlyOrgPR = installation.settings.onlyForOrgMembers && isPR
+    if (onlyOrgPR && githubAPI && settings.repoName && settings.triggeredByUsername) {
       log("Checking if user is in org")
-      const org = fullRepoName!.split("/")[0]
-      const user = triggeredByUser.login
-      const userInOrg = await isUserInOrg(token, user, org)
+      const org = settings.repoName.split("/")[0]
+      const userInOrg = await isUserInOrg(token, settings.triggeredByUsername, org)
       if (!userInOrg) {
-        res.status(403).send(`Not running because ${user} is not in ${org}.`)
+        res.status(403).send(`Not running because ${settings.triggeredByUsername} is not in ${org}.`)
         return
       }
     }
@@ -109,10 +118,10 @@ export async function githubDangerRunner(event: string, req: express.Request, re
     // In theory only a PR requires a custom branch, so we can check directly for that
     // in the event JSON and if it's not there then use master
     // prioritise the run metadata
-    const repoForDangerfile = run.repoSlug || runRepo
-    const dangerfileBranchForPR = req.body.pull_request ? req.body.pull_request.head.ref : "master"
+    const repoForDangerfile = run.repoSlug || settings.repoName
+    const dangerfileBranchForPR = req.body.pull_request ? req.body.pull_request.head.ref : null
     const neededDangerfileIsSameRepo = run.repoSlug === req.body.pull_request.head.repo.full_name
-    const branch = neededDangerfileIsSameRepo ? dangerfileBranchForPR : "master"
+    const branch = neededDangerfileIsSameRepo ? dangerfileBranchForPR : null
 
     const file = await getGitHubFileContents(token, repoForDangerfile, run.dangerfilePath, branch)
 
@@ -121,25 +130,29 @@ export async function githubDangerRunner(event: string, req: express.Request, re
   }
 
   const commentableRun = runs.find((run) => run.feedback === feedback.commentable)
-  if (commentableRun) {
-
-    const finalResults = allResults.reduce((curr: DangerResults, run: DangerResults) => {
-      return {
-        fails: [...curr.fails, ...run.fails],
-        markdowns: [...curr.markdowns, ...run.markdowns],
-        messages: [...curr.messages, ...run.messages],
-        warnings: [...curr.warnings, ...run.warnings],
-      }
-    }, { fails: [], markdowns: [], warnings: [], messages: [] })
-
-    const issue = getIssueNumber(req.body)
-    const githubAPI = githubAPIForCommentable(commentableRun, token, runRepo, issue)
-    const exec = executorForInstallation(new GitHub(githubAPI))
-    await exec.handleResults(finalResults)
-    console.log(finalResults) // tslint:disable-line
+  if (commentableRun && allResults.length) {
+    const finalResults = mergeResults(allResults)
+    commentOnResults(finalResults, commentableRun, token, settings)
   }
 
   res.status(200).send(`Run ${runs.length} Dangerfiles`)
+}
+
+export const mergeResults = (results: DangerResults[]): DangerResults => {
+  return results.reduce((curr: DangerResults, newResults: DangerResults) => {
+    return {
+      fails: [...curr.fails, ...newResults.fails],
+      markdowns: [...curr.markdowns, ...newResults.markdowns],
+      messages: [...curr.messages, ...newResults.messages],
+      warnings: [...curr.warnings, ...newResults.warnings],
+    }
+  }, { fails: [], markdowns: [], warnings: [], messages: [] })
+}
+
+export const commentOnResults = async (results: DangerResults, run, token, settings) => {
+    const githubAPI = githubAPIForCommentable(run, token, settings.repoName, settings.commentableID)
+    const exec = executorForInstallation(new GitHub(githubAPI))
+    await exec.handleResults(results)
 }
 
 // This doesn't feel great, but is OK for now
@@ -150,12 +163,12 @@ const getIssueNumber = (json: any): number | null => {
 }
 
 // This doesn't feel great, but is OK for now
-const getRepoSlug = (json: any): string | null => {
+  const getRepoSlug = (json: any): string | null => {
   if (json.repository) { return json.repository.full_name }
   return null
 }
 
-const githubAPIForCommentable
+  const githubAPIForCommentable
   = (run: DangerRun, token: string, repoSlug: string, issueNumber: number | null) => {
 
     const githubAPI = new GitHubAPI({ repoSlug, pullRequestID: String(issueNumber) }, token)
@@ -163,8 +176,9 @@ const githubAPIForCommentable
 
     // How can I get this from an API, if we cannot use /me ?
     // https://api.github.com/repos/PerilTest/PerilPRTester/issues/5/comments
+    // Talked to GH - they know it's an issue.
     githubAPI.getUserID = () => Promise.resolve(parseInt(PERIL_BOT_USER_ID, 10))
     return githubAPI
   }
 
-export default githubDangerRunner
+  export default githubDangerRunner

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -10,7 +10,7 @@ import { DangerResults } from "danger/distribution/dsl/DangerResults"
 import { getTemporaryAccessTokenForInstallation } from "../../api/github"
 import { DangerRun, dangerRunForRules, dsl, feedback } from "../../danger/danger_run"
 import { executorForInstallation, runDangerAgainstInstallation } from "../../danger/danger_runner"
-import { getInstallation, getRepo, GitHubInstallation, GithubRepo } from "../../db"
+import db, { GitHubInstallation, GithubRepo } from "../../db"
 import { getGitHubFileContents, isUserInOrg } from "../lib/github_helpers"
 
 /**
@@ -40,7 +40,7 @@ export async function githubDangerRunner(event: string, req: express.Request, re
   const action = req.body.action as string | null
   const installationID = req.body.installation.id as number
 
-  let installation = await getInstallation(installationID)
+  let installation = await db.getInstallation(installationID)
   if (!installation) {
     res.status(404).send(`Could not find installation with id: ${installationID}`)
     return
@@ -50,7 +50,7 @@ export async function githubDangerRunner(event: string, req: express.Request, re
   // So, we need to assume from here on, that this data is not always available
   const fullRepoName = req.body.repository && req.body.repository.full_name as string | null
   let repo = null as GithubRepo | null
-  if (fullRepoName) { repo = await getRepo(installationID, fullRepoName) }
+  if (fullRepoName) { repo = await db.getRepo(installationID, fullRepoName) }
   const runRepo = repo && repo.fullName || fullRepoName
 
   if (!runRepo) {

--- a/source/github/lib/github_helpers.ts
+++ b/source/github/lib/github_helpers.ts
@@ -8,7 +8,13 @@ export async function isUserInOrg(token: string, user: GitHubUser, org: string) 
     return res.status === 204
 }
 
-export async function getGitHubFileContents(token: string, repoSlug: string, path: string, ref: string | null) {
+/**
+ * There's definitely a time when you want access to a GitHub file
+ * but won't have an auth token to do it yet, this function should
+ * help out there, you can provide any auth token you want.
+ * Returns either the contents or nothing.
+ */
+export async function getGitHubFileContents(token: string | null, repoSlug: string, path: string, ref: string | null) {
     const refString = ref ? `ref=${ref}` : ""
     const res = await api(token, `repos/${repoSlug}/contents/${path}?${refString}`)
     const data = await res.json()
@@ -22,7 +28,10 @@ export async function getGitHubFileContents(token: string, repoSlug: string, pat
     }
 }
 
-async function api(token: string, path: string, headers: any = {}, body: any = {}, method: string = "GET") {
+/**
+ * A quick GitHub API client
+ */
+async function api(token: string | null, path: string, headers: any = {}, body: any = {}, method: string = "GET") {
     if (token) {
         headers.Authorization = `token ${token}`
     }

--- a/source/github/lib/github_helpers.ts
+++ b/source/github/lib/github_helpers.ts
@@ -8,8 +8,9 @@ export async function isUserInOrg(token: string, user: GitHubUser, org: string) 
     return res.status === 204
 }
 
-export async function getGitHubFileContents(token: string, repoSlug: string, path: string, ref: string) {
-    const res = await api(token, `repos/${repoSlug}/contents/${path}?ref=${ref}`)
+export async function getGitHubFileContents(token: string, repoSlug: string, path: string, ref: string | null) {
+    const refString = ref ? `ref=${ref}` : ""
+    const res = await api(token, `repos/${repoSlug}/contents/${path}?${refString}`)
     const data = await res.json()
     if (res.ok) {
         const buffer = new Buffer(data.content, "base64")

--- a/source/github/lib/github_helpers.ts
+++ b/source/github/lib/github_helpers.ts
@@ -32,9 +32,7 @@ export async function getGitHubFileContents(token: string | null, repoSlug: stri
  * A quick GitHub API client
  */
 async function api(token: string | null, path: string, headers: any = {}, body: any = {}, method: string = "GET") {
-    if (token) {
-        headers.Authorization = `token ${token}`
-    }
+    if (token) { headers.Authorization = `token ${token}` }
 
     const baseUrl = process.env.DANGER_GITHUB_API_BASE_URL || "https://api.github.com"
     return fetch(`${baseUrl}/${path}`, {

--- a/source/globals.ts
+++ b/source/globals.ts
@@ -41,6 +41,15 @@ export const WEB_URL = getEnv("WEB_URL")
 */
 export const DATABASE_JSON_FILE = getEnv("DATABASE_JSON_FILE")
 
+/**
+ * The ID for the GitHub installation, you can find this in the
+ * `integration_installation` event sent by GitHub. Only needed if
+ * you are doing JSON based Dangerfiles.
+ *
+ * In theory this can be optional if the repo is OSS.
+ */
+export const PERIL_ORG_INSTALLATION_ID = getEnv("PERIL_ORG_INSTALLATION_ID")
+
 /** Postgres db URL  */
 export const DATABASE_URL = getEnv("DATABASE_URL")
 

--- a/source/peril.ts
+++ b/source/peril.ts
@@ -8,6 +8,7 @@ import webhook from "./routing/router"
 // Error logging
 process.on("unhandledRejection", (reason: string, p: any) => {
   console.log("Error: ", reason)  // tslint:disable-line
+  throw reason
 })
 
 const app = express()

--- a/source/routing/_tests/_router.test.ts
+++ b/source/routing/_tests/_router.test.ts
@@ -1,11 +1,11 @@
 const pingMock = jest.fn()
-jest.mock("../../github/events/ping", () => { return { ping: pingMock } })
+jest.mock("../../github/events/ping", () =>  ({ ping: pingMock }))
 
 const createInstallationMock = jest.fn()
-jest.mock("../../github/events/create_installation", () => { return { createInstallation: createInstallationMock } })
+jest.mock("../../github/events/create_installation", () => ({ createInstallation: createInstallationMock }))
 
 const githubRunnerMock = jest.fn()
-jest.mock("../../github/events/github_runner", () => { return { githubDangerRunner: githubRunnerMock } })
+jest.mock("../../github/events/github_runner", () => ({ githubDangerRunner: githubRunnerMock }))
 
 import { githubRouting } from "../router"
 

--- a/source/routing/router.ts
+++ b/source/routing/router.ts
@@ -1,6 +1,6 @@
 import winston from "../logger"
 
-import { deleteInstallation } from "../db"
+import db from "../db"
 import { createInstallation } from "../github/events/create_installation"
 import { githubDangerRunner } from "../github/events/github_runner"
 import { ping } from "../github/events/ping"
@@ -46,7 +46,7 @@ export const githubRouting = (event, req, res, next) => {
       // Delete any integrations that have uninstalled Peril :wave:
       if (action === "deleted") {
         info(` - Deleting integration ${installation.id}`)
-        deleteInstallation(installation.id)
+        db.deleteInstallation(installation.id)
       }
 
       break

--- a/yarn.lock
+++ b/yarn.lock
@@ -307,31 +307,7 @@ babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.24.0:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.0.tgz#8f36a0a77f5c155aed6f920b844d23ba56742a02"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-generator "^6.24.0"
-    babel-helpers "^6.23.0"
-    babel-messages "^6.23.0"
-    babel-register "^6.24.0"
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
-    babel-traverse "^6.23.1"
-    babel-types "^6.23.0"
-    babylon "^6.11.0"
-    convert-source-map "^1.1.0"
-    debug "^2.1.1"
-    json5 "^0.5.0"
-    lodash "^4.2.0"
-    minimatch "^3.0.2"
-    path-is-absolute "^1.0.0"
-    private "^0.1.6"
-    slash "^1.0.0"
-    source-map "^0.5.0"
-
-babel-core@^6.24.1:
+babel-core@^6.0.0, babel-core@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.24.1.tgz#8c428564dce1e1f41fb337ec34f4c3b022b5ad83"
   dependencies:
@@ -355,20 +331,7 @@ babel-core@^6.24.1:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-generator@^6.18.0, babel-generator@^6.24.0:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.0.tgz#eba270a8cc4ce6e09a61be43465d7c62c1f87c56"
-  dependencies:
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-    detect-indent "^4.0.0"
-    jsesc "^1.3.0"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-babel-generator@^6.24.1:
+babel-generator@^6.18.0, babel-generator@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.24.1.tgz#e715f486c58ded25649d888944d52aa07c5d9497"
   dependencies:
@@ -474,13 +437,6 @@ babel-helper-replace-supers@^6.22.0, babel-helper-replace-supers@^6.23.0:
     babel-template "^6.23.0"
     babel-traverse "^6.23.0"
     babel-types "^6.23.0"
-
-babel-helpers@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-helpers/-/babel-helpers-6.23.0.tgz#4f8f2e092d0b6a8808a4bde79c27f1e2ecf0d992"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-template "^6.23.0"
 
 babel-helpers@^6.24.1:
   version "6.24.1"
@@ -817,18 +773,6 @@ babel-preset-stage-3@^6.22.0:
     babel-plugin-transform-exponentiation-operator "^6.22.0"
     babel-plugin-transform-object-rest-spread "^6.22.0"
 
-babel-register@^6.24.0:
-  version "6.24.0"
-  resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.0.tgz#5e89f8463ba9970356d02eb07dabe3308b080cfd"
-  dependencies:
-    babel-core "^6.24.0"
-    babel-runtime "^6.22.0"
-    core-js "^2.4.0"
-    home-or-tmp "^2.0.0"
-    lodash "^4.2.0"
-    mkdirp "^0.5.1"
-    source-map-support "^0.4.2"
-
 babel-register@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.24.1.tgz#7e10e13a2f71065bdfad5a1787ba45bca6ded75f"
@@ -848,17 +792,7 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
-babel-template@^6.16.0, babel-template@^6.22.0, babel-template@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.23.0.tgz#04d4f270adbb3aa704a8143ae26faa529238e638"
-  dependencies:
-    babel-runtime "^6.22.0"
-    babel-traverse "^6.23.0"
-    babel-types "^6.23.0"
-    babylon "^6.11.0"
-    lodash "^4.2.0"
-
-babel-template@^6.24.1:
+babel-template@^6.16.0, babel-template@^6.22.0, babel-template@^6.23.0, babel-template@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.24.1.tgz#04ae514f1f93b3a2537f2a0f60a5a45fb8308333"
   dependencies:
@@ -868,21 +802,7 @@ babel-template@^6.24.1:
     babylon "^6.11.0"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.23.1:
-  version "6.23.1"
-  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
-  dependencies:
-    babel-code-frame "^6.22.0"
-    babel-messages "^6.23.0"
-    babel-runtime "^6.22.0"
-    babel-types "^6.23.0"
-    babylon "^6.15.0"
-    debug "^2.2.0"
-    globals "^9.0.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-babel-traverse@^6.24.1:
+babel-traverse@^6.18.0, babel-traverse@^6.22.0, babel-traverse@^6.23.0, babel-traverse@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.24.1.tgz#ab36673fd356f9a0948659e7b338d5feadb31695"
   dependencies:
@@ -896,16 +816,7 @@ babel-traverse@^6.24.1:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
-  dependencies:
-    babel-runtime "^6.22.0"
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^1.0.1"
-
-babel-types@^6.24.1:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.22.0, babel-types@^6.23.0, babel-types@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.24.1.tgz#a136879dc15b3606bda0d90c1fc74304c2ff0975"
   dependencies:
@@ -1092,7 +1003,7 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1:
+chalk@^1.0.0, chalk@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.1.tgz#509afb67066e7499f7eb3535c77445772ae2d019"
   dependencies:
@@ -1102,7 +1013,7 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^1.1.3:
+chalk@^1.1.0, chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -1374,13 +1285,13 @@ dateformat@^1.0.11:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@2, debug@2.6.3, debug@^2.1.1, debug@^2.2.0, debug@^2.6.0:
+debug@2, debug@2.6.3, debug@^2.2.0:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
     ms "0.7.2"
 
-debug@2.6.1:
+debug@2.6.1, debug@^2.1.1, debug@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -4261,9 +4172,9 @@ typescript@^2.1.4:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
 
-typescript@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.2.tgz#606022508479b55ffa368b58fee963a03dfd7b0c"
+typescript@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
 
 typings-core@^2.2.0:
   version "2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,6 @@
 # yarn lockfile v1
 
 
-"@types/config@^0.0.32":
-  version "0.0.32"
-  resolved "https://registry.yarnpkg.com/@types/config/-/config-0.0.32.tgz#c106055802d78e234e28374adc4dad460d098558"
-
 "@types/debug@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.29.tgz#a1e514adfbd92f03a224ba54d693111dbf1f3754"
@@ -1139,12 +1135,6 @@ concat-stream@^1.4.7:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
-
-config@^1.20.4:
-  version "1.25.1"
-  resolved "https://registry.yarnpkg.com/config/-/config-1.25.1.tgz#72ac51cde81e2c77c6b3b66d0130dae527a19c92"
-  dependencies:
-    json5 "0.4.0"
 
 configstore@^2.0.0:
   version "2.1.0"
@@ -2564,10 +2554,6 @@ json2ts@orta/json2ts#ts-less:
   resolved "https://codeload.github.com/orta/json2ts/tar.gz/9b944d04fcb849c4ab5d84f322cae57d9329b6b2"
   dependencies:
     underscore "^1.8.3"
-
-json5@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-0.4.0.tgz#054352e4c4c80c86c0923877d449de176a732c8d"
 
 json5@^0.5.0:
   version "0.5.1"
@@ -4168,11 +4154,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@^2.1.4:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
-
-typescript@^2.3.2:
+typescript@^2.1.4, typescript@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
 


### PR DESCRIPTION
This means your _peril_ config can be in a JSON file in a repo, so it can easily be diffed, collaborated on etc. Probably a really good pattern for controlling your rules for repos overall too IMO.