### PR TITLE
Add org checks for changing  Dangerfiles on a PR

### DIFF
--- a/source/github/events/_tests/_github_runner-prs.test.ts
+++ b/source/github/events/_tests/_github_runner-prs.test.ts
@@ -1,9 +1,12 @@
 const getRepoFake = () => Promise.resolve({ id: "123", fake: true })
 jest.mock("../../../db", () => ({ default: { getRepo: getRepoFake } }))
 
-let currentDangerfile = ""
-const contentsMock = jest.fn(() => Promise.resolve(currentDangerfile))
-jest.mock("../../../github/lib/github_helpers", () => ({ getGitHubFileContents: contentsMock }))
+const contentsMock = jest.fn(() => Promise.resolve("// empty"))
+const userRepoAccessMock = jest.fn(() => Promise.resolve(true))
+jest.mock("../../../github/lib/github_helpers", () => ({
+  canUserWriteToRepo: userRepoAccessMock,
+  getGitHubFileContents: contentsMock,
+}))
 
 const runnerMock = jest.fn(() => Promise.resolve("OK"))
 jest.mock("../../../danger/danger_runner", () => ({ runDangerAgainstInstallation: runnerMock }))
@@ -18,7 +21,9 @@ const apiFixtures = resolve(__dirname, "fixtures")
 const fixture = file => JSON.parse(readFileSync(resolve(apiFixtures, file), "utf8"))
 
 it("runs an Dangerfile for a PR with a local", async () => {
-  currentDangerfile = "fail('dangerfile')"
+  contentsMock.mockImplementationOnce(() => Promise.resolve("fail('dangerfile')"))
+  contentsMock.mockImplementationOnce(() => Promise.resolve("fail('dangerfile')"))
+
   const body = fixture("pull_request_opened.json")
   const settings = await setupForRequest({ body } as any)
 
@@ -29,4 +34,39 @@ it("runs an Dangerfile for a PR with a local", async () => {
 
   expect(call[0]).toEqual("fail('dangerfile')")
   expect(call[1]).toEqual("dangerfile.pr")
+})
+
+describe("when someone edits the dangerfile", () => {
+  beforeEach(() => {
+    runnerMock.mockReset()
+  })
+
+  it("fails a run when a Dangerfile is edited by somone without access", async () => {
+    contentsMock.mockImplementationOnce(() => Promise.resolve("// safe"))
+    contentsMock.mockImplementationOnce(() => Promise.resolve("// unsafe"))
+    userRepoAccessMock.mockImplementationOnce(() => Promise.resolve(false))
+
+    const body = fixture("pull_request_opened.json")
+    const settings = await setupForRequest({ body } as any)
+
+    const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })!
+
+    const results = await runPRRun(run, settings, "token", body.pull_request)
+    expect(runnerMock).not.toBeCalled()
+    expect(results!.messages[0].message).toContain("Not running Danger rules")
+  })
+
+  it("runs a Dangerfile when edited by somone with access", async () => {
+    contentsMock.mockImplementationOnce(() => Promise.resolve("// safe"))
+    contentsMock.mockImplementationOnce(() => Promise.resolve("// unsafe"))
+    userRepoAccessMock.mockImplementationOnce(() => Promise.resolve(true))
+
+    const body = fixture("pull_request_opened.json")
+    const settings = await setupForRequest({ body } as any)
+
+    const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })!
+
+    const results = await runPRRun(run, settings, "token", body.pull_request)
+    expect(runnerMock).toBeCalled()
+  })
 })

--- a/source/github/lib/github_helpers.ts
+++ b/source/github/lib/github_helpers.ts
@@ -2,10 +2,11 @@ import fetch from "../../api/fetch"
 import { GitHubUser } from "../../db/types"
 import winston from "../../logger"
 
-export async function isUserInOrg(token: string, user: GitHubUser, org: string) {
-  // https://developer.github.com/v3/orgs/members/#check-membership
-  const res = await api(token, `orgs/${org}/members/${user}`)
-  return res.status === 204
+export async function canUserWriteToRepo(token: string, user: GitHubUser, repoSlug: string) {
+  // https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
+  const req = await api(token, `repos/${repoSlug}/collaborators/${user.login}/permission`)
+  const res = await req.json()
+  return res.permission === "admin" || res.permission === "write"
 }
 
 /**


### PR DESCRIPTION
Adds the final safety net around running Danger on an open source org. Making sure that changes from non-admins are not allowed to run code with escalated permissions.

Fixes #95 