### PR TITLE
refactor(types): add body-parser types

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "author": "Orta",
   "license": "MIT",
   "dependencies": {
+    "@types/body-parser": "^1.16.4",
     "@types/debug": "^0.0.29",
     "@types/ejs": "^2.3.33",
     "@types/express": "^4.0.34",

--- a/source/peril.ts
+++ b/source/peril.ts
@@ -1,8 +1,7 @@
+import * as bodyParser from "body-parser"
 import * as express from "express"
 import * as xhub from "express-x-hub"
 import { PERIL_WEBHOOK_SECRET } from "./globals"
-
-const bodyParser = require("body-parser") // tslint:disable-line
 import logger from "./logger"
 import webhook from "./routing/router"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@types/body-parser@^1.16.4":
+  version "1.16.4"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.16.4.tgz#96f3660e6f88a677fee7250f5a5e6d6bda3c76bb"
+  dependencies:
+    "@types/express" "*"
+    "@types/node" "*"
+
 "@types/debug@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-0.0.29.tgz#a1e514adfbd92f03a224ba54d693111dbf1f3754"
@@ -15,6 +22,13 @@
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.0.44.tgz#a1c3bd5d80e93c72fba91a03f5412c47f21d4ae7"
   dependencies:
     "@types/node" "*"
+
+"@types/express@*":
+  version "4.0.36"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.0.36.tgz#14eb47de7ecb10319f0a2fb1cf971aa8680758c2"
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/serve-static" "*"
 
 "@types/express@^4.0.34":
   version "4.0.35"


### PR DESCRIPTION
I am aiming to get familiar with this codebase and hope to contribute small things (adding types, fixing typos, etc.) as I navigate through the codebase and try to understand what's going on.

I was working on a small Express-based project of my own and learned that there are types for the body-parser package, and that was one of the first things I saw in `peril.ts`. 😄 