### PR TITLE
Allow any repo to run without having to declare it in the settings

### DIFF
--- a/source/danger/danger_run.ts
+++ b/source/danger/danger_run.ts
@@ -61,9 +61,9 @@ export const dangerRunForRules = (
   }
 
   return {
-    event,
     action,
     dslType: dslTypeForEvent(event),
+    event,
     ...dangerRepresentationforPath(path),
     feedback: feedbackTypeForEvent(event),
   }

--- a/source/github/events/_tests/_github_runner-events.test.ts
+++ b/source/github/events/_tests/_github_runner-events.test.ts
@@ -1,5 +1,6 @@
+const mockGetRepo = jest.fn()
 jest.mock("../../../db", () => ({
-  default: { getRepo: () => Promise.resolve({ id: "123", fake: true }) },
+  default: { getRepo: mockGetRepo },
 }))
 
 const mockContents = jest.fn((token, repo, path) => {
@@ -20,6 +21,23 @@ const apiFixtures = resolve(__dirname, "fixtures")
 const fixture = file => JSON.parse(readFileSync(resolve(apiFixtures, file), "utf8"))
 
 it("runs an Dangerfile for an issue with a local", async () => {
+  mockGetRepo.mockImplementationOnce(() => Promise.resolve({ id: "123", fake: true }))
+
+  const body = fixture("issue_comment_created.json")
+  const req = { body } as any
+  const settings = await setupForRequest(req)
+  expect(settings.commentableID).toBeTruthy()
+
+  const run = dangerRunForRules("issue_comment", "created", { issue_comment: "dangerfile.issue" })!
+
+  const result = await runEventRun(run, settings, "token", body)
+  // See above i nthe mock for the link
+  expect(result!.warnings[0].message).toEqual("issue worked")
+})
+
+it("can handle a db returning nil for the repo with an Dangerfile for an issue with a local", async () => {
+  mockGetRepo.mockImplementationOnce(() => Promise.resolve(null))
+
   const body = fixture("issue_comment_created.json")
   const req = { body } as any
   const settings = await setupForRequest(req)

--- a/source/github/events/_tests/_github_runner-setup.test.ts
+++ b/source/github/events/_tests/_github_runner-setup.test.ts
@@ -20,8 +20,8 @@ describe("makes the right settings for", () => {
       hasRelatedCommentable: true,
       isRepoEvent: true,
       isTriggeredByUser: true,
-      repo: { fake: true },
       repoName: "danger/peril",
+      repoSpecificRules: {},
       triggeredByUsername: "orta",
     })
   })
@@ -35,8 +35,8 @@ describe("makes the right settings for", () => {
       hasRelatedCommentable: false,
       isRepoEvent: false,
       isTriggeredByUser: true,
-      repo: null,
       repoName: false,
+      repoSpecificRules: {},
       triggeredByUsername: "orta",
     })
   })

--- a/source/github/lib/github_helpers.ts
+++ b/source/github/lib/github_helpers.ts
@@ -2,9 +2,9 @@ import fetch from "../../api/fetch"
 import { GitHubUser } from "../../db/types"
 import winston from "../../logger"
 
-export async function canUserWriteToRepo(token: string, user: GitHubUser, repoSlug: string) {
+export async function canUserWriteToRepo(token: string, user: string, repoSlug: string) {
   // https://developer.github.com/v3/repos/collaborators/#review-a-users-permission-level
-  const req = await api(token, `repos/${repoSlug}/collaborators/${user.login}/permission`)
+  const req = await api(token, `repos/${repoSlug}/collaborators/${user}/permission`)
   const res = await req.json()
   return res.permission === "admin" || res.permission === "write"
 }

--- a/source/routing/router.ts
+++ b/source/routing/router.ts
@@ -70,7 +70,7 @@ export const githubRouting = (event, req: express.Request, res: express.Response
     }
 
     default: {
-      info(` - passing ${event} to GH Dangerfile rule router`)
+      info(`Passing ${event} to GH Dangerfile rule router`)
 
       // Look out for changes to the settting JSON file and update the
       // db accordingly


### PR DESCRIPTION
Fixes #100

This just hit me also, which means I'm in a good place to test it. I feel like this was really an issue with two bits of data coming into the functions which made it confusing which to use. Now the settings is more constrained.

Plus I strengthened the typings in the github runner and it caught a few things 👍 