### PR TITLE
Update to danger's 2a5 which allows in-memory dangerfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-stage-3": "^6.22.0",
     "body-parser": "^1.15.2",
-    "danger": "2.0.0-alpha.3",
+    "danger": "2.0.0-alpha.5",
     "dotenv": "^4.0.0",
     "ejs": "^2.4.2",
     "express": "^4.13.4",

--- a/source/danger/_tests/_danger_runner.test.ts
+++ b/source/danger/_tests/_danger_runner.test.ts
@@ -21,7 +21,8 @@ describe("evaling", () => {
   it("runs a typescript dangerfile with fixtured data", async () => {
     const platform = fixturedGitHub()
     const executor = executorForInstallation(platform)
-    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_empty.ts`, executor)
+    const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_empty.ts`, "utf8")
+    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_empty.ts`, contents, executor)
     expect(results).toEqual({
       fails: [],
       markdowns: [],
@@ -33,14 +34,18 @@ describe("evaling", () => {
   it("highlights some of the security measures", async () => {
     const platform = fixturedGitHub()
     const executor = executorForInstallation(platform)
-    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_insecure.ts`, executor)
+    const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_insecure.ts`, "utf8")
+
+    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_insecure.ts`, contents, executor)
     expect(results.markdowns).toEqual(["`Object.keys(process.env).length` is 0"])
   })
 
   it("allows external modules", async () => {
     const platform = fixturedGitHub()
     const executor = executorForInstallation(platform)
-    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_import_module.ts`, executor)
+    const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_import_module.ts`, "utf8")
+
+    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_import_module.ts`, contents, executor)
     expect(results.markdowns).toEqual([":tada:"])
   })
 
@@ -55,7 +60,7 @@ describe("evaling", () => {
       writeFileSync(localDangerfile, contents, { encoding: "utf8" })
     }
 
-    const results = await runDangerAgainstFile(localDangerfile, executor)
+    const results = await runDangerAgainstFile(localDangerfile, contents, executor)
     expect(results.markdowns).toEqual([":tada:"])
   })
 
@@ -64,7 +69,8 @@ describe("evaling", () => {
     const platform = fixturedGitHub()
     const executor = executorForInstallation(platform)
     // The executor will return results etc in the next release
-    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_insecure.js`, executor)
+    const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_insecure.ts`, "utf8")
+    const results = await runDangerAgainstFile(`${dangerfilesFixtures}/dangerfile_insecure.js`, contents, executor)
     expect(results).toEqual({
       fails: [],
       markdowns: [],

--- a/source/danger/danger_runner.ts
+++ b/source/danger/danger_runner.ts
@@ -43,23 +43,25 @@ export async function runDangerAgainstInstallation(
   const exec = await executorForInstallation(platform)
 
   const randomName = Math.random().toString(36)
-  const localDangerfile = path.resolve("../../dangerfile_runtime_env", "danger-" + randomName + path.extname(filepath))
-  await write(localDangerfile, contents)
+  const localDangerfilePath = path.resolve(
+    "../../dangerfile_runtime_env",
+    "danger-" + randomName + path.extname(filepath)
+  )
 
-  return await runDangerAgainstFile(localDangerfile, exec)
+  return await runDangerAgainstFile(localDangerfilePath, contents, exec)
 }
 
 /**
  * Sets up the custom peril environment and runs danger against a local file
  */
-export async function runDangerAgainstFile(file: string, exec: Executor) {
+export async function runDangerAgainstFile(filepath: string, contents: string, exec: Executor) {
   const runtimeEnv = await exec.setupDanger()
   // runtimeEnv.rquire.root = dangerfile_runtime_env
   let results: DangerResults
   try {
-    results = await runDangerfileEnvironment(file, runtimeEnv)
+    results = await runDangerfileEnvironment(filepath, contents, runtimeEnv)
   } catch (error) {
-    results = resultsForCaughtError(file, error)
+    results = resultsForCaughtError(filepath, error)
   }
   return results
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1398,14 +1398,14 @@ danger-plugin-yarn@^0.2.10:
   optionalDependencies:
     esdoc "^0.5.2"
 
-danger@2.0.0-alpha.3:
-  version "2.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-2.0.0-alpha.3.tgz#0c21386fd0823e8eba9edc7571c9e8247bbfc074"
+danger@2.0.0-alpha.5:
+  version "2.0.0-alpha.5"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-2.0.0-alpha.5.tgz#3692428fe3ada49d0712a47d123f3e7b9bcc9066"
   dependencies:
     babel-polyfill "^6.20.0"
     chalk "^2.0.0"
     commander "^2.9.0"
-    debug "^2.6.0"
+    debug "^3.0.0"
     github "^9.2.0"
     jsome "^2.3.25"
     jsonpointer "^4.0.1"
@@ -1430,7 +1430,7 @@ date-fns@^1.28.5:
   version "1.28.5"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
-debug@2, debug@2.6.3, debug@^2.2.0, debug@^2.6.0, debug@^2.6.3:
+debug@2, debug@2.6.3, debug@^2.2.0, debug@^2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.3.tgz#0f7eb8c30965ec08c72accfa0130c8b79984141d"
   dependencies:
@@ -1441,6 +1441,12 @@ debug@2.6.1, debug@^2.1.1:
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
     ms "0.7.2"
+
+debug@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.0.0.tgz#1d2feae53349047b08b264ec41906ba17a8516e4"
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
@@ -3164,6 +3170,10 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
+ms@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
+
 ms@^0.7.1:
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.3.tgz#708155a5e44e33f5fd0fc53e81d0d40a91be1fff"
@@ -4555,7 +4565,7 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-vm2@patriksimek/vm2:
+"vm2@github:patriksimek/vm2":
   version "3.4.6"
   resolved "https://codeload.github.com/patriksimek/vm2/tar.gz/0711926ba6e6fbfb89277d8033cfd11b69888e46"
 


### PR DESCRIPTION
#114 failed because of heroku's read-only FS, very reasonable. I was taking a guess. This moves it to work entirely in-memory. 