### PR TITLE
Feature - Adding node cluster support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "type": "node2",
       "request": "launch",
       "name": "Launch Dev Web Server",
-      "program": "${workspaceRoot}/out/peril.js",
+      "program": "${workspaceRoot}/out/index.js",
       "args": [
         "--harmony-async-await"
       ],
@@ -24,22 +24,22 @@
       "port": 5858,
       "outFiles": [],
       "sourceMaps": true
-    }, 
+    },
     {
-        "name": "Run Tests With Debugger (slower, use npm run watch for normal work)",
-        "type": "node",
-        "request": "launch",
-        "port": 5858,
-        "address": "localhost",
-        "stopOnEntry": false,
-        "runtimeExecutable": null,
-        "runtimeArgs": [
-            "--debug-brk",
-            "./node_modules/.bin/jest",
-            "-i"
-        ],
-        "cwd": "${workspaceRoot}",
-        "sourceMaps": true
+      "name": "Run Tests With Debugger (slower, use npm run watch for normal work)",
+      "type": "node",
+      "request": "launch",
+      "port": 5858,
+      "address": "localhost",
+      "stopOnEntry": false,
+      "runtimeExecutable": null,
+      "runtimeArgs": [
+        "--debug-brk",
+        "./node_modules/.bin/jest",
+        "-i"
+      ],
+      "cwd": "${workspaceRoot}",
+      "sourceMaps": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "Warning Danger! Danger!",
   "scripts": {
-    "start": "node out/peril.js",
+    "start": "node out/index.js",
     "compile": "tsc -watch -p ./",
     "build": "yarn tsc",
     "postinstall": "yarn build; if [ $DATABASE_JSON_FILE ]; then yarn run setup; fi",

--- a/source/index.ts
+++ b/source/index.ts
@@ -1,0 +1,29 @@
+import * as cluster from 'cluster'
+import * as os from 'os'
+
+import logger from "./logger"
+import peril from './peril';
+
+const WORKERS = process.env.NODE_ENV === 'production' ?
+  process.env.WEB_CONCURRENCY || os.cpus().length :
+  1;
+
+if (cluster.isMaster) {
+  logger.info(`[CLUSTER] Master cluster setting up ${WORKERS} workers...`);
+  for (let i = 0; i < WORKERS; i++) {
+    cluster.fork(); // create a worker
+  }
+
+  cluster.on('online', (worker) => {
+    logger.info(`[CLUSTER] Worker ${worker.process.pid} is online`);
+  });
+
+  cluster.on('exit', (worker, code, signal) => {
+    logger.info(`[CLUSTER] Worker ${worker.process.pid} died with code: ${code}, and signal: ${signal}`);
+    logger.info('[CLUSTER] Starting a new worker');
+    // start a new worker when it crashes
+    cluster.fork();
+  });
+} else {
+  peril();
+}

--- a/source/peril.ts
+++ b/source/peril.ts
@@ -3,33 +3,38 @@ import * as express from "express"
 import * as xhub from "express-x-hub"
 
 import { PERIL_WEBHOOK_SECRET, PUBLIC_FACING_API } from "./globals"
-import logger from "./logger"
 
 import prDSLRunner from "./api/pr/dsl"
+import logger from "./logger"
 import webhook from "./routing/router"
 
-// Error logging
-process.on("unhandledRejection", (reason: string, p: any) => {
-  console.log("Error: ", reason) // tslint:disable-line
-  throw reason
-})
+const peril = () => {
 
-const app = express()
-app.set("port", process.env.PORT || 5000)
-app.set("view engine", "ejs")
-app.use(xhub({ algorith: "sha1", secret: PERIL_WEBHOOK_SECRET }))
-app.use(bodyParser.json())
-app.use(express.static("public"))
+  // Error logging
+  process.on("unhandledRejection", (reason: string, p: any) => {
+    console.log("Error: ", reason) // tslint:disable-line
+    throw reason
+  })
 
-app.post("/webhook", webhook)
+  const app = express()
+  app.set("port", process.env.PORT || 5000)
+  app.set("view engine", "ejs")
+  app.use(xhub({ algorith: "sha1", secret: PERIL_WEBHOOK_SECRET }))
+  app.use(bodyParser.json())
+  app.use(express.static("public"))
 
-if (PUBLIC_FACING_API) {
-  console.log("This is a public facing Peril instance.") // tslint:disable-line
-  app.get("/api/v1/pr/dsl", prDSLRunner)
+  app.post("/webhook", webhook)
+
+  if (PUBLIC_FACING_API) {
+    console.log("This is a public facing Peril instance.") // tslint:disable-line
+    app.get("/api/v1/pr/dsl", prDSLRunner)
+  }
+
+  // Start server
+  app.listen(app.get("port"), () => {
+    console.log(`Started server at http://localhost:${process.env.PORT || 5000}`) // tslint:disable-line
+    logger.info("Started up server.")
+  })
 }
 
-// Start server
-app.listen(app.get("port"), () => {
-  console.log(`Started server at http://localhost:${process.env.PORT || 5000}`) // tslint:disable-line
-  logger.info("Started up server.")
-})
+export default peril;


### PR DESCRIPTION
Adding [node cluster](https://nodejs.org/api/cluster.html) support to allow server to:

- Recover automatically from crashes 
- Improve resource usage when multi-core servers are used

I think this will be particularly useful for github organizations with a lot of repositories running either on heroku professional dynos or any other mulit-core machine.