### PR TITLE
Adding more details to PERIL_BOT_USER_ID docs

### DIFF
--- a/docs/setup_for_org.md
+++ b/docs/setup_for_org.md
@@ -134,7 +134,11 @@ The GitHub API doesn't let the bot know what it's user ID is yet, so you'll need
 
 > `https://api.github.com/repos/[org]/[repo]/issues/[pr_or_issue_id]/comments`
 
-Then you can scroll down to find the ID of the Peril user account. Set this on your server using: `heroku config:add PERIL_BOT_USER_ID="[bot-id]" --app [my_heroku_peril_app]`.
+Check [Github API docs](https://developer.github.com/v3/issues/comments/#list-comments-on-an-issue) or [here](https://platform.github.community/t/obtaining-the-id-of-the-bot-user/2076/5) if you need more info on how to perform the request or [here](https://developer.github.com/v3/auth/#basic-authentication) if you are having trouble authenticating.
+
+Then you can scroll down on the API JSON response to find the `"user"."id"` of the Peril user account. It will be a comment where the `"user"."type"` value is `"Bot"`.
+
+Set this on your server using: `heroku config:add PERIL_BOT_USER_ID="[bot-id]" --app [my_heroku_peril_app]`.
 
 ### Peril crashed, so I changed something and want to run the same event
 


### PR DESCRIPTION
I expanded a bit the docs on how do get the bot id for those not that familiar with Github API.

I also managed to get it via the GraphQL API, but was not sure how it would fit the docs. I will leave the query here just in case anyone figures it out in the future how to not be so verbose

```graphql
query BotIdForIssueOrPullRequest($url: URI!) {
  resource(url: $url) {
    __typename
    ...pr
    ...issue
  }
}

fragment issue on Issue {
  comments(first: 100) {
    nodes {
      author {
        ...author
      }
    }
  }
}

fragment pr on PullRequest {
  comments(first: 10) {
    nodes {
      author {
        ...author
      }
    }
  }
}

fragment author on Bot {
  login
  databaseId
}
```

and the data would be just the PR or Issue URL, no id handling needed

```json
{
  "url": "https://api.github.com/repos/[org]/[repo]/issues/[pr_or_issue_id]"
}
```
