### PR TITLE
Adds support for passing through specific ENV Vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 2017-08-25
+
+Added the ability to expose an ENV var via the `peril` object in the runtime, I wanted to use the Slack API in one of our Artsy Dangerfiles, but there wasn't a way to actually pass the secret to the Dangerfile. - Orta

--- a/README.md
+++ b/README.md
@@ -32,19 +32,27 @@ In order to support danger.systems features, there is an ENV var `"PUBLIC_FACING
 
   This will return the DSL JSON for a specific Pull Request. Supports JSONP.
 
-### Danger Plugins
+### Peril Settings
 
-Right now you can add Danger plugins by adding a key `modules` with an array of string inside the settings object of your database. If you're using a JSON db, it'd look like this:
 
 ```json
 {
   "settings": {
-    "modules": ["danger-plugin-yarn", "danger-plugin-spellcheck"]
+    "modules": ["danger-plugin-yarn", "danger-plugin-spellcheck"],
+    "env_vars": ["MY_CUSTOM_ENV_VAR]
   }
   ...
 }
 ```
 
+#### Plugins / Modules
+
+Right now you can add Danger plugins by adding a key `modules` with an array of string inside the settings object of your database.
+
 These will be added to your install via `yarn add [plugins]` at heroku build-time. This means that to update your modules
 you will need to ship a new commit to heroku. I'd recommend [this gist's](https://gist.github.com/csu/d22e60114051a0a182d2)
 technique.
+
+#### Env Vars
+
+You might want to expose specific ENV VARs to your Dangerfiles, this will take the values from your `process.env` and put them on `peril.env` inside the Dangerfiles.

--- a/source/danger/_tests/_danger_runner_paths.test.ts
+++ b/source/danger/_tests/_danger_runner_paths.test.ts
@@ -14,7 +14,7 @@ import {
   executorForInstallation,
   handleDangerResults,
   runDangerAgainstFile,
-  runDangerAgainstInstallation,
+  runDangerForInstallation,
 } from "../danger_runner"
 
 import { existsSync, readFileSync, writeFileSync } from "fs"
@@ -28,7 +28,7 @@ describe("paths", () => {
   it("passes an absolute string to runDangerfileEnvironment", async () => {
     const platform = fixturedGitHub()
     const executor = executorForInstallation(platform)
-    const results = await runDangerAgainstInstallation(`dangerfile_empty.ts`, "", null, dsl.pr)
+    const results = await runDangerForInstallation(`dangerfile_empty.ts`, "", null, dsl.pr, {})
 
     const firstArgCalled = mockRunDangerfileEnvironment.mock.calls[0][0]
     expect(firstArgCalled).toContain("/peril/")

--- a/source/db/index.ts
+++ b/source/db/index.ts
@@ -23,6 +23,13 @@ export type DangerfileReferenceString = string
  */
 export type PerilEventString = string
 
+export interface GitHubInstallationSettings {
+  /** An array of modules for Peril to install, requires a re-deploy of the server to update. */
+  modules?: string[]
+  /** A array of allowed ENV vars. */
+  env_vars?: string[]
+}
+
 /** An individual integration of Danger via Peril, this is like the org */
 export interface GitHubInstallation {
   /**
@@ -34,10 +41,7 @@ export interface GitHubInstallation {
    * In our DB this is represented as a JSON type, so you should always have settings
    * as a nullable type. These are the entire installation settings.
    */
-  settings: {
-    /** A set of space separated modules for Peril to install, requires a re-deploy of the server to update. */
-    modules?: string[]
-  }
+  settings: GitHubInstallationSettings
 
   /** Having rules in here would mean that it would happen on _any_ event, another JSON type in the DB */
   rules: RunnerRuleset

--- a/source/github/events/_tests/_github_runner-events.test.ts
+++ b/source/github/events/_tests/_github_runner-events.test.ts
@@ -26,7 +26,7 @@ it("runs an Dangerfile for an issue with a local", async () => {
   const body = fixture("issue_comment_created.json")
   const req = { body, headers: { "X-GitHub-Delivery": "123" } } as any
 
-  const settings = await setupForRequest(req)
+  const settings = await setupForRequest(req, {})
   expect(settings.commentableID).toBeTruthy()
 
   const run = dangerRunForRules("issue_comment", "created", { issue_comment: "dangerfile.issue" })!
@@ -41,7 +41,7 @@ it("can handle a db returning nil for the repo with an Dangerfile for an issue w
 
   const body = fixture("issue_comment_created.json")
   const req = { body, headers: { "X-GitHub-Delivery": "123" } } as any
-  const settings = await setupForRequest(req)
+  const settings = await setupForRequest(req, {})
   expect(settings.commentableID).toBeTruthy()
 
   const run = dangerRunForRules("issue_comment", "created", { issue_comment: "dangerfile.issue" })!

--- a/source/github/events/_tests/_github_runner-prs.test.ts
+++ b/source/github/events/_tests/_github_runner-prs.test.ts
@@ -8,7 +8,7 @@ jest.mock("../../../github/lib/github_helpers", () => ({
 }))
 
 const mockRunner = jest.fn(() => Promise.resolve("OK"))
-jest.mock("../../../danger/danger_runner", () => ({ runDangerAgainstInstallation: mockRunner }))
+jest.mock("../../../danger/danger_runner", () => ({ runDangerForInstallation: mockRunner }))
 
 import { readFileSync } from "fs"
 import { resolve } from "path"
@@ -24,7 +24,7 @@ it("runs an Dangerfile for a PR with a local", async () => {
   mockContents.mockImplementationOnce(() => Promise.resolve("fail('dangerfile')"))
 
   const body = fixture("pull_request_opened.json")
-  const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any)
+  const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
   const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.pr" })!
 
@@ -46,7 +46,7 @@ describe("when someone edits the dangerfile", () => {
     mockUserRepoAccess.mockImplementationOnce(() => Promise.resolve(false))
 
     const body = fixture("pull_request_opened.json")
-    const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any)
+    const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
     const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })!
 
@@ -61,7 +61,7 @@ describe("when someone edits the dangerfile", () => {
     mockUserRepoAccess.mockImplementationOnce(() => Promise.resolve(true))
 
     const body = fixture("pull_request_opened.json")
-    const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any)
+    const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
     const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })!
 

--- a/source/github/events/_tests/_github_runner-runs.test.ts
+++ b/source/github/events/_tests/_github_runner-runs.test.ts
@@ -6,6 +6,7 @@ const defaultRun: GitHubRunSettings = {
   commentableID: 2,
   eventID: "09876",
   hasRelatedCommentable: true,
+  installationSettings: {},
   isRepoEvent: true,
   isTriggeredByUser: true,
   repoName: "danger/peril",

--- a/source/github/events/_tests/_github_runner-setup.test.ts
+++ b/source/github/events/_tests/_github_runner-setup.test.ts
@@ -13,12 +13,13 @@ const requestWithFixturedJSON = (name: string): any => {
 describe("makes the right settings for", () => {
   it("a pull_request_opened event", async () => {
     const pr = requestWithFixturedJSON("pull_request_opened")
-    const settings = await setupForRequest(pr)
+    const settings = await setupForRequest(pr, {})
 
     expect(settings).toEqual({
       commentableID: 2,
       eventID: "12345",
       hasRelatedCommentable: true,
+      installationSettings: {},
       isRepoEvent: true,
       isTriggeredByUser: true,
       repoName: "danger/peril",
@@ -29,12 +30,13 @@ describe("makes the right settings for", () => {
 
   it("an integration_installation_created event", async () => {
     const pr = requestWithFixturedJSON("integration_installation_created")
-    const settings = await setupForRequest(pr)
+    const settings = await setupForRequest(pr, {})
 
     expect(settings).toEqual({
       commentableID: null,
       eventID: "12345",
       hasRelatedCommentable: false,
+      installationSettings: {},
       isRepoEvent: false,
       isTriggeredByUser: true,
       repoName: false,


### PR DESCRIPTION
Added the ability to expose an ENV var via the `peril` object in the runtime, I wanted to use the Slack API in one of our Artsy Dangerfiles, but there wasn't a way to actually pass the secret to the Dangerfile. 


This also brings back the CHANGELOG, I don't think there's "versions" but I do tend to work in batches. So I won't force others to do it, but I'll leave myself notes in there.