### PR TITLE
Danger: Update to alpha 13

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-stage-3": "^6.22.0",
     "body-parser": "^1.15.2",
-    "danger": "2.0.0-alpha.12",
+    "danger": "2.0.0-alpha.13",
     "dotenv": "^4.0.0",
     "ejs": "^2.4.2",
     "express": "^4.13.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1654,9 +1654,9 @@ danger-plugin-yarn@^0.3.0:
   optionalDependencies:
     esdoc "^0.5.2"
 
-danger@2.0.0-alpha.12:
-  version "2.0.0-alpha.12"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-2.0.0-alpha.12.tgz#788cdb6d4e2618a9e3915ac4ec62c9715b528453"
+danger@2.0.0-alpha.13:
+  version "2.0.0-alpha.13"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-2.0.0-alpha.13.tgz#2a1ce1bb9618878c0782fef030d9af153be880f6"
   dependencies:
     babel-polyfill "7.0.0-alpha.19"
     chalk "^2.0.0"


### PR DESCRIPTION
Saw this in the logs:

```
Request failed [404]: https://github.com/timehop/apicard/pull/932.diff
Response: Not Found
```

Poked around and saw this commit for alpha 13: https://github.com/danger/danger-js/commit/51e0bf838970b1c3d0e8e5515680abf759f1fc53