### PR TITLE
pr.body type definition now nullable

### DIFF
--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -252,9 +252,9 @@ export const runPRRun = async (
 
 ## Full state of PR run:
 
-\`\`\`json      
+\`\`\`json
 ${JSON.stringify(stateForErrorHandling, null, "  ")}
-\`\`\`   
+\`\`\`
       `
   }
 
@@ -266,7 +266,7 @@ ${JSON.stringify(stateForErrorHandling, null, "  ")}
       run.dslType,
       settings.installationSettings
     )
-    if (pr.body.includes("Peril: Debug")) {
+    if (pr.body !== null && pr.body.includes("Peril: Debug")) {
       results.markdowns.push(reportData("Showing PR details due to including 'Peril: Debug'"))
     }
     return results

--- a/source/github/events/types/pull_request_opened.types.ts
+++ b/source/github/events/types/pull_request_opened.types.ts
@@ -311,7 +311,7 @@ export interface Pull_request {
   locked: boolean
   title: string
   user: User
-  body: string
+  body: string | null
   created_at: string
   updated_at: string
   closed_at?: any


### PR DESCRIPTION
i noticed that peril was crashing on some test prs i was opening that
were just one-liners with only a title. in that case, the `pr.body` is
`null` and not `""`

i only see this one reference to `pr.body`, although a safer thing might be to cast the `body` to a string when ingesting the webhook data. thoughts?