### PR TITLE
Factor out getInstallationId

### DIFF
--- a/source/api/pr/dsl.ts
+++ b/source/api/pr/dsl.ts
@@ -41,7 +41,7 @@ const prDSLRunner = async (req: express.Request, res: express.Response, next: ex
     throw new Error("You can't support PR DSLs without setting up the PERIL_ORG_INSTALLATION_ID")
   }
 
-  const token = await getTemporaryAccessTokenForInstallation(parseInt(PERIL_ORG_INSTALLATION_ID, 10))
+  const token = await getTemporaryAccessTokenForInstallation(PERIL_ORG_INSTALLATION_ID)
 
   const ghDetails = {
     fullName: query.owner + "/" + query.repo,

--- a/source/db/json.ts
+++ b/source/db/json.ts
@@ -29,14 +29,6 @@ For example:
 const info = (message: string) => winston.info(`[json db] - ${message}`)
 const error = (message: string) => winston.error(`[json db] - ${message}`)
 
-const getInstallationId = (id: string | undefined): number => {
-  let installationId: number | undefined = parseInt(id as string, 10)
-  if (Number.isNaN(installationId)) {
-    installationId = undefined
-  }
-  return installationId as number
-}
-
 let org: GitHubInstallation = null as any
 
 const jsonDatabase = (dangerFilePath: DangerfileReferenceString): DatabaseAdaptor => ({
@@ -93,7 +85,7 @@ const jsonDatabase = (dangerFilePath: DangerfileReferenceString): DatabaseAdapto
         throwNoPerilInstallationID()
       }
 
-      const token = await getTemporaryAccessTokenForInstallation(getInstallationId(PERIL_ORG_INSTALLATION_ID))
+      const token = await getTemporaryAccessTokenForInstallation(PERIL_ORG_INSTALLATION_ID)
       file = await getGitHubFileContents(token, repo, path, null)
     }
 
@@ -110,7 +102,7 @@ const jsonDatabase = (dangerFilePath: DangerfileReferenceString): DatabaseAdapto
       // installation related calls
 
       org = {
-        id: getInstallationId(PERIL_ORG_INSTALLATION_ID),
+        id: PERIL_ORG_INSTALLATION_ID,
         repos: parsedOrg.repos || {},
         rules: parsedOrg.rules || {},
         scheduler: parsedOrg.scheduler || {},

--- a/source/globals.ts
+++ b/source/globals.ts
@@ -42,6 +42,14 @@ export const WEB_URL = getEnv("WEB_URL")
  */
 export const DATABASE_JSON_FILE = getEnv("DATABASE_JSON_FILE")
 
+const getInstallationId = (id: string | undefined): number => {
+  let installationId: number | undefined = parseInt(id as string, 10)
+  if (Number.isNaN(installationId)) {
+    installationId = undefined
+  }
+  return installationId as number
+}
+
 /**
  * The ID for the GitHub installation, you can find this in the
  * `integration_installation` event sent by GitHub. Only needed if
@@ -49,7 +57,7 @@ export const DATABASE_JSON_FILE = getEnv("DATABASE_JSON_FILE")
  *
  * In theory this can be optional if the repo is OSS.
  */
-export const PERIL_ORG_INSTALLATION_ID = getEnv("PERIL_ORG_INSTALLATION_ID")
+export const PERIL_ORG_INSTALLATION_ID = getInstallationId(getEnv("PERIL_ORG_INSTALLATION_ID"))
 
 /** Postgres db URL */
 export const DATABASE_URL = getEnv("DATABASE_URL")


### PR DESCRIPTION
This allows us to re-use the same logic for the installation ID parsing in both the DSL and the JSON DB.

This is a small change that I plan to use in follow up work.