### PR TITLE
Extract GitHub file access utility

### DIFF
--- a/source/db/_tests/__snapshots__/_json.test.ts.snap
+++ b/source/db/_tests/__snapshots__/_json.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Raises with a bad URL 1`] = `[SyntaxError: Unexpected token u in JSON at position 0]`;
+exports[`Raises with a bad URL 1`] = `[Error: Could not find find a JSON file for Peril settings. It's likely that Peril cannot connect to orta/other@settings.json, check the logs for more info above here. You'll probably need to make changes to your  "DATABASE_JSON_FILE" in your ENV vars.]`;
 
 exports[`makes the right calls to GitHub gets repo rules correct 1`] = `
 Object {

--- a/source/db/_tests/_json.test.ts
+++ b/source/db/_tests/_json.test.ts
@@ -14,8 +14,7 @@ const legitSettings = `{
 }`
 
 const mockGHContents = jest.fn()
-jest.mock("../../github/lib/github_helpers", () => ({ getGitHubFileContents: mockGHContents }))
-jest.mock("../../api/github.ts", () => ({ getTemporaryAccessTokenForInstallation: () => Promise.resolve("123") }))
+jest.mock("../../github/lib/github_helpers", () => ({ getGitHubFileContentsWithoutToken: mockGHContents }))
 
 import { DatabaseAdaptor } from "../index"
 import jsonDB from "../json"


### PR DESCRIPTION
This extracts a util that is able to get a file from GitHub with just the Peril environment setup (no need to manually do a token dance).

It is intended that this util will be used in post install setup scripts in danger plugins, so ease of use is important.