### PR TITLE
Support doing multiple runs from the same event

### DIFF
--- a/source/danger/_tests/_danger_run.test.ts
+++ b/source/danger/_tests/_danger_run.test.ts
@@ -10,67 +10,85 @@ import {
 describe("for ping", () => {
   it("returns an action when ping is in the rules", () => {
     const rules = { ping: "dangerfile.js" }
-    expect(dangerRunForRules("ping", null, rules)).toEqual({
-      action: null,
-      branch: "master",
-      dangerfilePath: "dangerfile.js",
-      dslType: dsl.import,
-      event: "ping",
-      feedback: feedback.silent,
-      repoSlug: undefined,
-    })
+    expect(dangerRunForRules("ping", null, rules)).toEqual([
+      {
+        action: null,
+        branch: "master",
+        dangerfilePath: "dangerfile.js",
+        dslType: dsl.import,
+        event: "ping",
+        feedback: feedback.silent,
+        repoSlug: undefined,
+      },
+    ])
   })
 
   it("returns nothing when ping is not in the rules", () => {
     const rules = {}
-    expect(dangerRunForRules("ping", null, rules)).toBeNull()
+    expect(dangerRunForRules("ping", null, rules)).toEqual([])
   })
 })
 
 describe("for PRs", () => {
   it("returns a PR when PR is in the rules", () => {
     const rules = { pull_request: "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "created", rules)).toEqual({
-      action: "created",
-      branch: "master",
-      dangerfilePath: "dangerfile.js",
-      dslType: dsl.pr,
-      event: "pull_request",
-      feedback: feedback.commentable,
-      repoSlug: undefined,
-    })
+    expect(dangerRunForRules("pull_request", "created", rules)).toEqual([
+      {
+        action: "created",
+        branch: "master",
+        dangerfilePath: "dangerfile.js",
+        dslType: dsl.pr,
+        event: "pull_request",
+        feedback: feedback.commentable,
+        repoSlug: undefined,
+      },
+    ])
   })
 
   // Same semantics
   it("returns a PR run when all sub events are globbed in the rules", () => {
     const rules = { "pull_request.*": "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "updated", rules)).toEqual({
-      action: "updated",
-      branch: "master",
-      dangerfilePath: "dangerfile.js",
-      dslType: dsl.pr,
-      event: "pull_request",
-      feedback: feedback.commentable,
-      repoSlug: undefined,
-    })
+    expect(dangerRunForRules("pull_request", "updated", rules)).toEqual([
+      {
+        action: "updated",
+        branch: "master",
+        dangerfilePath: "dangerfile.js",
+        dslType: dsl.pr,
+        event: "pull_request",
+        feedback: feedback.commentable,
+        repoSlug: undefined,
+      },
+    ])
   })
 
   it("returns null when you only ask for a specific action", () => {
     const rules = { "pull_request.created": "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "updated", rules)).toBeNull()
+    expect(dangerRunForRules("pull_request", "updated", rules)).toEqual([])
   })
 
   it("returns a PR run when all sub events are globbed in the rules", () => {
     const rules = { "pull_request.deleted": "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "deleted", rules)).toEqual({
-      action: "deleted",
-      branch: "master",
-      dangerfilePath: "dangerfile.js",
-      dslType: dsl.pr,
-      event: "pull_request",
-      feedback: feedback.commentable,
-      repoSlug: undefined,
-    })
+    expect(dangerRunForRules("pull_request", "deleted", rules)).toEqual([
+      {
+        action: "deleted",
+        branch: "master",
+        dangerfilePath: "dangerfile.js",
+        dslType: dsl.pr,
+        event: "pull_request",
+        feedback: feedback.commentable,
+        repoSlug: undefined,
+      },
+    ])
+  })
+
+  it("returns many runs when there are mutliple potential matches", () => {
+    const rules = {
+      issue: "dangerfile.js",
+      pull_request: "dangerfile.js",
+      "pull_request.*": "dangerfile.js",
+      "pull_request.updated": "dangerfile.js",
+    }
+    expect(dangerRunForRules("pull_request", "updated", rules).length).toEqual(3)
   })
 })
 

--- a/source/danger/danger_run.ts
+++ b/source/danger/danger_run.ts
@@ -37,11 +37,11 @@ export const dangerRunForRules = (
   event: string,
   action: string | null,
   rule: RunnerRuleset | undefined | null
-): DangerRun | null => {
+): DangerRun[] => {
   // tslint:disable-line
   // Can't do anything with nothing
   if (!rule) {
-    return null
+    return []
   }
 
   // We can just see if anything exists at the right places,
@@ -49,20 +49,14 @@ export const dangerRunForRules = (
   const isDirect = rule[event]
   const globsAll = rule[event + ".*"]
   const eventDotAction = action && rule[event + "." + action]
-  const path = isDirect || globsAll || eventDotAction
-
-  // Bail, we can't do anything
-  if (!path) {
-    return null
-  }
-
-  return {
+  const possibilities = [isDirect, globsAll, eventDotAction].filter(p => p) as string[]
+  return possibilities.map(path => ({
     action,
     dslType: dslTypeForEvent(event),
     event,
     ...dangerRepresentationforPath(path),
     feedback: feedbackTypeForEvent(event),
-  }
+  }))
 }
 
 interface RepresentationForURL {

--- a/source/github/events/_tests/_github_runner-events.test.ts
+++ b/source/github/events/_tests/_github_runner-events.test.ts
@@ -30,7 +30,7 @@ it("runs an Dangerfile for an issue with a local", async () => {
   const settings = await setupForRequest(req, {})
   expect(settings.commentableID).toBeTruthy()
 
-  const run = dangerRunForRules("issue_comment", "created", { issue_comment: "dangerfile.issue" })!
+  const run = dangerRunForRules("issue_comment", "created", { issue_comment: "dangerfile.issue" })[0]
 
   const result = await runEventRun(run, settings, "token", body)
   // See above in the mock for the link
@@ -46,7 +46,7 @@ it("adds github util functions and apis to the DSL for non-PR events", async () 
 
   const dangerfileForRun = "warn(danger.github.api)"
   mockGHContents.mockImplementationOnce(() => Promise.resolve(dangerfileForRun))
-  const run = dangerRunForRules("issue_comment", "created", { issue_comment: "warn_with_api" })!
+  const run = dangerRunForRules("issue_comment", "created", { issue_comment: "warn_with_api" })[0]
 
   const result = await runEventRun(run, settings, "token", body)
   expect(result!.warnings[0].message).not.toEqual("null")
@@ -60,7 +60,7 @@ it("can handle a db returning nil for the repo with an Dangerfile for an issue w
   const settings = await setupForRequest(req, {})
   expect(settings.commentableID).toBeTruthy()
 
-  const run = dangerRunForRules("issue_comment", "created", { issue_comment: "dangerfile.issue" })!
+  const run = dangerRunForRules("issue_comment", "created", { issue_comment: "dangerfile.issue" })[0]
 
   const result = await runEventRun(run, settings, "token", body)
   // See above i nthe mock for the link

--- a/source/github/events/_tests/_github_runner-prs.test.ts
+++ b/source/github/events/_tests/_github_runner-prs.test.ts
@@ -26,7 +26,7 @@ it("runs an Dangerfile for a PR with a local", async () => {
   const body = fixture("pull_request_opened.json")
   const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
-  const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.pr" })!
+  const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.pr" })[0]
 
   await runPRRun(run, settings, "token", body.pull_request)
   const call = mockRunner.mock.calls[0]
@@ -48,7 +48,7 @@ describe("when someone edits the dangerfile", () => {
     const body = fixture("pull_request_opened.json")
     const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
-    const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })!
+    const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })[0]
 
     const results = await runPRRun(run, settings, "token", body.pull_request)
     expect(mockRunner).not.toBeCalled()
@@ -63,7 +63,7 @@ describe("when someone edits the dangerfile", () => {
     const body = fixture("pull_request_opened.json")
     const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
-    const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })!
+    const run = dangerRunForRules("pull_request", "opened", { pull_request: "dangerfile.no.access.pr" })[0]
 
     const results = await runPRRun(run, settings, "token", body.pull_request)
     expect(mockRunner).toBeCalled()

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -111,7 +111,7 @@ export function runsForEvent(
 ) {
   const installationRun = dangerRunForRules(event, action, installation.rules)
   const repoRun = dangerRunForRules(event, action, settings.repoSpecificRules)
-  return [installationRun, repoRun].filter(r => !!r) as DangerRun[]
+  return [...installationRun, ...repoRun].filter(r => !!r) as DangerRun[]
 }
 
 export const runEverything = async (


### PR DESCRIPTION
https://github.com/artsy/artsy-danger/pull/34 added a specific RFC which wanted to only run on closed PRs, but it looks like Peril didn't support that. So #167 and this PR. I could probably use this as a reasonable to break out our PR dangerfile into many also.