### PR TITLE
Create a peril danger-JS runner with hyper functions

### DIFF
--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,3 @@
+## Peril Staging
+
+* Uses a mongo instance ()

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "danger": "^3"
   },
   "dependencies": {
-    "@octokit/rest": "^14.0.4",
+    "@octokit/rest": "^14.0.6",
     "@types/agenda": "^1.0.1",
     "@types/body-parser": "^1.16.8",
     "@types/debug": "^0.0.30",
@@ -56,13 +56,15 @@
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
     "body-parser": "^1.18.2",
-    "danger": "^3.1.0",
+    "danger": "^3.1.3",
     "danger-plugin-yarn": "^1.2.1",
     "dotenv": "^4.0.0",
     "ejs": "^2.5.7",
     "express": "^4.16.2",
     "express-x-hub": "^1.0.4",
+    "get-stdin": "^5.0.1",
     "glob": "^7.1.2",
+    "hyper-aws4": "^1.1.3",
     "jest": "^22.1.4",
     "json2ts": "orta/json2ts#ts-less",
     "json5": "^0.5.1",
@@ -89,7 +91,9 @@
       ".(ts|tsx)": "<rootDir>/node_modules/ts-jest/preprocessor.js"
     },
     "testRegex": "(/_tests/.*.test.ts$)",
-    "moduleFileExtensions": ["ts", "tsx", "js"]
+    "moduleFileExtensions": ["ts", "tsx", "js"],
+    "roots": ["<rootDir>/source"],
+    "modulePaths": ["<rootDir>/source"]
   },
   "lint-staged": {
     "*.json": ["yarn prettier --write", "git add"],

--- a/source/api/pr/dsl.ts
+++ b/source/api/pr/dsl.ts
@@ -3,7 +3,7 @@ import winston from "../../logger"
 
 import * as fs from "fs"
 
-import { getTemporaryAccessTokenForInstallation } from "../../api/github"
+import { getTemporaryAccessTokenForInstallation } from "api/github"
 
 import { PERIL_ORG_INSTALLATION_ID } from "../../globals"
 
@@ -19,6 +19,8 @@ import { Executor, ExecutorOptions } from "danger/distribution/runner/Executor"
 import { createDangerfileRuntimeEnvironment, runDangerfileEnvironment } from "danger/distribution/runner/runners/vm2"
 import { executorForInstallation } from "../../danger/danger_runner"
 import { githubAPIForCommentable } from "../../github/events/github_runner"
+
+import inline from "danger/distribution/runner/runners/inline"
 
 const prDSLRunner = async (req: express.Request, res: express.Response, next: express.NextFunction) => {
   winston.log("router", `Recieved OK`)
@@ -53,7 +55,7 @@ const prDSLRunner = async (req: express.Request, res: express.Response, next: ex
   const gh = new GitHub(githubAPI)
   const platform = perilPlatform(dsl.pr, gh, {})
 
-  const exec = await executorForInstallation(platform)
+  const exec = await executorForInstallation(platform, inline)
   const dangerDSL = await exec.dslForDanger()
 
   // Remove this to reduce data

--- a/source/danger/_tests/_danger_run.test.ts
+++ b/source/danger/_tests/_danger_run.test.ts
@@ -18,6 +18,7 @@ describe("for ping", () => {
         dslType: dsl.import,
         event: "ping",
         feedback: feedback.silent,
+        referenceString: "dangerfile.js",
         repoSlug: undefined,
       },
     ])
@@ -40,6 +41,7 @@ describe("for PRs", () => {
         dslType: dsl.pr,
         event: "pull_request",
         feedback: feedback.commentable,
+        referenceString: "dangerfile.js",
         repoSlug: undefined,
       },
     ])
@@ -56,6 +58,7 @@ describe("for PRs", () => {
         dslType: dsl.pr,
         event: "pull_request",
         feedback: feedback.commentable,
+        referenceString: "dangerfile.js",
         repoSlug: undefined,
       },
     ])
@@ -76,6 +79,7 @@ describe("for PRs", () => {
         dslType: dsl.pr,
         event: "pull_request",
         feedback: feedback.commentable,
+        referenceString: "dangerfile.js",
         repoSlug: undefined,
       },
     ])
@@ -98,6 +102,7 @@ describe("dangerRepresentationforPath", () => {
     expect(dangerRepresentationforPath(path)).toEqual({
       branch: "master",
       dangerfilePath: "dangerfile.ts",
+      referenceString: "dangerfile.ts",
       repoSlug: undefined,
     })
   })
@@ -107,6 +112,7 @@ describe("dangerRepresentationforPath", () => {
     expect(dangerRepresentationforPath(path)).toEqual({
       branch: "master",
       dangerfilePath: "dangerfile.ts",
+      referenceString: "orta/eigen@dangerfile.ts",
       repoSlug: "orta/eigen",
     })
   })
@@ -116,6 +122,7 @@ describe("dangerRepresentationforPath", () => {
     expect(dangerRepresentationforPath(path)).toEqual({
       branch: "branch",
       dangerfilePath: "dangerfile.ts",
+      referenceString: "orta/eigen@dangerfile.ts#branch",
       repoSlug: "orta/eigen",
     })
   })
@@ -125,6 +132,7 @@ describe("dangerRepresentationforPath", () => {
     expect(dangerRepresentationforPath(path)).toEqual({
       branch: "branch",
       dangerfilePath: "dangerfile.ts",
+      referenceString: "dangerfile.ts#branch",
       repoSlug: undefined,
     })
   })

--- a/source/danger/_tests/_danger_runner.test.ts
+++ b/source/danger/_tests/_danger_runner.test.ts
@@ -5,7 +5,7 @@ import { Platform } from "danger/distribution/platforms/platform"
 
 import { perilObjectForInstallation } from "danger/append_peril"
 import fixturedGitHub from "../../api/_tests/fixtureAPI"
-import { executorForInstallation, handleDangerResults, runDangerAgainstFile } from "../danger_runner"
+import { executorForInstallation, handleDangerResults, runDangerAgainstFileInline } from "../danger_runner"
 
 import { PerilDSL } from "danger/distribution/dsl/DangerDSL"
 import vm2 from "danger/distribution/runner/runners/vm2"
@@ -37,7 +37,7 @@ describe("evaling", () => {
     const platform = fixturedGitHub()
     const executor = executorForInstallation(platform, vm2)
     const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_empty.ts`, "utf8")
-    const results = await runDangerAgainstFile(
+    const results = await runDangerAgainstFileInline(
       `${dangerfilesFixtures}/dangerfile_empty.ts`,
       contents,
       installationSettings,
@@ -58,7 +58,7 @@ describe("evaling", () => {
     const path = `${dangerfilesFixtures}/dangerfile_insecure.ts`
     const contents = readFileSync(path, "utf8")
 
-    const results = await runDangerAgainstFile(path, contents, installationSettings, executor, peril)
+    const results = await runDangerAgainstFileInline(path, contents, installationSettings, executor, peril)
     expect(results.markdowns).toEqual(["`Object.keys(process.env).length` is 0"])
   })
 
@@ -70,7 +70,7 @@ describe("evaling", () => {
       const path = `${dangerfilesFixtures}/dangerfile_import_module.ts`
 
       const contents = readFileSync(path, "utf8")
-      const results = await runDangerAgainstFile(path, contents, installationSettings, executor, peril)
+      const results = await runDangerAgainstFileInline(path, contents, installationSettings, executor, peril)
       expect(results.messages).toEqual([{ message: ":tada: - congrats on your new release" }])
     })
 
@@ -81,7 +81,7 @@ describe("evaling", () => {
       const localDangerfile = resolve("./dangerfile_runtime_env", "dangerfile_import_complex_module.ts")
       const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_import_module.ts`, "utf8")
 
-      const results = await runDangerAgainstFile(localDangerfile, contents, installationSettings, executor, peril)
+      const results = await runDangerAgainstFileInline(localDangerfile, contents, installationSettings, executor, peril)
       expect(results.messages).toEqual([{ message: ":tada: - congrats on your new release" }])
     })
   }
@@ -93,7 +93,7 @@ describe("evaling", () => {
     const localDangerfile = resolve(`${dangerfilesFixtures}/dangerfile_peril_obj.ts`)
     const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_peril_obj.ts`, "utf8")
 
-    const results = await runDangerAgainstFile(localDangerfile, contents, installationSettings, executor, peril)
+    const results = await runDangerAgainstFileInline(localDangerfile, contents, installationSettings, executor, peril)
     expect(results.markdowns).toEqual([JSON.stringify(peril, null, "  ")])
   })
 
@@ -105,7 +105,7 @@ describe("evaling", () => {
     const path = `${dangerfilesFixtures}/dangerfile_insecure.ts`
 
     const contents = readFileSync(path, "utf8")
-    const results = await runDangerAgainstFile(path, contents, installationSettings, executor, peril)
+    const results = await runDangerAgainstFileInline(path, contents, installationSettings, executor, peril)
     expect(results).toEqual({
       fails: [],
       markdowns: [],

--- a/source/danger/_tests/_danger_runner.test.ts
+++ b/source/danger/_tests/_danger_runner.test.ts
@@ -8,7 +8,7 @@ import fixturedGitHub from "../../api/_tests/fixtureAPI"
 import { executorForInstallation, handleDangerResults, runDangerAgainstFile } from "../danger_runner"
 
 import { PerilDSL } from "danger/distribution/dsl/DangerDSL"
-import inline from "danger/distribution/runner/runners/inline"
+import vm2 from "danger/distribution/runner/runners/vm2"
 import { existsSync, readFileSync, writeFileSync } from "fs"
 import { tmpdir } from "os"
 import { basename, resolve } from "path"
@@ -35,7 +35,7 @@ const installationSettings = {
 describe("evaling", () => {
   it("runs a typescript dangerfile with fixtured data", async () => {
     const platform = fixturedGitHub()
-    const executor = executorForInstallation(platform, inline)
+    const executor = executorForInstallation(platform, vm2)
     const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_empty.ts`, "utf8")
     const results = await runDangerAgainstFile(
       `${dangerfilesFixtures}/dangerfile_empty.ts`,
@@ -54,7 +54,7 @@ describe("evaling", () => {
 
   it("highlights some of the security measures", async () => {
     const platform = fixturedGitHub()
-    const executor = executorForInstallation(platform, inline)
+    const executor = executorForInstallation(platform, vm2)
     const path = `${dangerfilesFixtures}/dangerfile_insecure.ts`
     const contents = readFileSync(path, "utf8")
 
@@ -66,7 +66,7 @@ describe("evaling", () => {
   if (!process.env.WALLABY_PRODUCTION) {
     it("allows external modules", async () => {
       const platform = fixturedGitHub()
-      const executor = executorForInstallation(platform, inline)
+      const executor = executorForInstallation(platform, vm2)
       const path = `${dangerfilesFixtures}/dangerfile_import_module.ts`
 
       const contents = readFileSync(path, "utf8")
@@ -76,7 +76,7 @@ describe("evaling", () => {
 
     it("allows external modules with internal resolving ", async () => {
       const platform = fixturedGitHub()
-      const executor = executorForInstallation(platform, inline)
+      const executor = executorForInstallation(platform, vm2)
 
       const localDangerfile = resolve("./dangerfile_runtime_env", "dangerfile_import_complex_module.ts")
       const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_import_module.ts`, "utf8")
@@ -88,7 +88,7 @@ describe("evaling", () => {
 
   it("has a peril object defined in global scope", async () => {
     const platform = fixturedGitHub()
-    const executor = executorForInstallation(platform, inline)
+    const executor = executorForInstallation(platform, vm2)
 
     const localDangerfile = resolve(`${dangerfilesFixtures}/dangerfile_peril_obj.ts`)
     const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_peril_obj.ts`, "utf8")
@@ -100,7 +100,7 @@ describe("evaling", () => {
   // I wonder if the babel setup isn't quite right yet for this test
   it.skip("runs a JS dangerfile with fixtured data", async () => {
     const platform = fixturedGitHub()
-    const executor = executorForInstallation(platform, inline)
+    const executor = executorForInstallation(platform, vm2)
     // The executor will return results etc in the next release
     const path = `${dangerfilesFixtures}/dangerfile_insecure.ts`
 
@@ -116,7 +116,7 @@ describe("evaling", () => {
 
   it("generates the correct modified/deleted/created paths", async () => {
     const platform = fixturedGitHub()
-    const executor = executorForInstallation(platform, inline)
+    const executor = executorForInstallation(platform, vm2)
     const dsl = await executor.dslForDanger()
     expect(dsl.git.created_files.length).toBeGreaterThan(0)
     expect(dsl.git.modified_files.length).toBeGreaterThan(0)

--- a/source/danger/_tests/_danger_runner_paths.test.ts
+++ b/source/danger/_tests/_danger_runner_paths.test.ts
@@ -14,6 +14,7 @@ import {
   runDangerForInstallation,
 } from "../danger_runner"
 
+import vm2 from "danger/distribution/runner/runners/vm2"
 import { dsl } from "../danger_run"
 
 const defaultSettings = {
@@ -34,7 +35,7 @@ jest.mock("api/github", () => ({
 describe("paths", () => {
   it("passes an absolute string to runDangerfileEnvironment", async () => {
     const platform = fixturedGitHub()
-    const executor = executorForInstallation(platform)
+    const executor = executorForInstallation(platform, vm2)
     const results = await runDangerForInstallation(`dangerfile_empty.ts`, "", null, dsl.pr, installationSettings)
 
     const path = mockRunDangerfileEnvironment.mock.calls[0][0]

--- a/source/danger/_tests/_danger_runner_paths.test.ts
+++ b/source/danger/_tests/_danger_runner_paths.test.ts
@@ -10,7 +10,7 @@ import fixturedGitHub from "../../api/_tests/fixtureAPI"
 import {
   executorForInstallation,
   handleDangerResults,
-  runDangerAgainstFile,
+  runDangerAgainstFileInline,
   runDangerForInstallation,
 } from "../danger_runner"
 

--- a/source/danger/_tests/_danger_runner_paths.test.ts
+++ b/source/danger/_tests/_danger_runner_paths.test.ts
@@ -27,7 +27,7 @@ const installationSettings = {
   settings: defaultSettings,
 }
 
-jest.mock("../../api/github", () => ({
+jest.mock("api/github", () => ({
   getTemporaryAccessTokenForInstallation: () => Promise.resolve("123"),
 }))
 

--- a/source/danger/_tests/_danger_runner_peril.test.ts
+++ b/source/danger/_tests/_danger_runner_peril.test.ts
@@ -1,7 +1,7 @@
-import { appendPerilContextToDSL } from "../danger_runner"
+import { appendPerilContextToDSL } from "danger/append_peril"
 
 const mockToken = "1234535345"
-jest.mock("../../api/github", () => ({
+jest.mock("api/github", () => ({
   getTemporaryAccessTokenForInstallation: () => Promise.resolve(mockToken),
 }))
 

--- a/source/danger/append_peril.ts
+++ b/source/danger/append_peril.ts
@@ -1,0 +1,51 @@
+import { Platform } from "danger/distribution/platforms/platform"
+import winston from "../logger"
+
+import { GitHubInstallation } from "../db"
+import { GitHubInstallationSettings } from "../db/GitHubRepoSettings"
+import { RootObject as PR } from "../github/events/types/pull_request_opened.types"
+
+import { getCISourceForEnv } from "danger/distribution/ci_source/get_ci_source"
+import { PerilDSL } from "danger/distribution/dsl/DangerDSL"
+import { DangerResults } from "danger/distribution/dsl/DangerResults"
+import { GitHub } from "danger/distribution/platforms/GitHub"
+import { GitHubAPI } from "danger/distribution/platforms/github/GitHubAPI"
+import { Executor, ExecutorOptions } from "danger/distribution/runner/Executor"
+import inlineRunner from "danger/distribution/runner/runners/vm2"
+
+import * as NodeGithub from "@octokit/rest"
+
+import { getTemporaryAccessTokenForInstallation } from "api/github"
+import { contextForDanger, DangerContext } from "danger/distribution/runner/Dangerfile"
+import { generateTaskSchedulerForInstallation } from "../tasks/scheduleTask"
+import { InstallationToRun } from "./danger_runner"
+
+export async function appendPerilContextToDSL(installationID: number, sandbox: DangerContext, peril: PerilDSL) {
+  if (sandbox.danger && sandbox.danger.github) {
+    const token = await getTemporaryAccessTokenForInstallation(installationID)
+    const api = new NodeGithub()
+
+    api.authenticate({
+      token,
+      type: "integration",
+    })
+
+    sandbox.danger.github.api = api
+  }
+
+  // TODO: Add this to the Danger DSL in Danger, as an optional
+  const anySandbox = sandbox as any
+  anySandbox.peril = peril
+}
+
+export const perilObjectForInstallation = (
+  installation: InstallationToRun,
+  environment: any,
+  peril: any
+): PerilDSL => ({
+  ...peril,
+  env:
+    installation.settings.env_vars &&
+    Object.assign({}, ...installation.settings.env_vars.map(k => ({ [k]: environment[k] }))),
+  runTask: generateTaskSchedulerForInstallation(installation.id),
+})

--- a/source/danger/danger_run.ts
+++ b/source/danger/danger_run.ts
@@ -59,7 +59,7 @@ export const dangerRunForRules = (
   }))
 }
 
-interface RepresentationForURL {
+export interface RepresentationForURL {
   dangerfilePath: string
   branch: string
   repoSlug: string | undefined

--- a/source/danger/danger_run.ts
+++ b/source/danger/danger_run.ts
@@ -63,6 +63,7 @@ export interface RepresentationForURL {
   dangerfilePath: string
   branch: string
   repoSlug: string | undefined
+  referenceString: DangerfileReferenceString
 }
 
 /** Takes a DangerfileReferenceString and lets you know where to find it globally */
@@ -72,6 +73,7 @@ export const dangerRepresentationforPath = (value: DangerfileReferenceString): R
     branch: value.includes("#") ? value.split("#")[1] : "master",
     dangerfilePath: afterAt.split("#")[0],
     repoSlug: value.includes("@") ? value.split("@")[0] : undefined,
+    referenceString: value,
   }
 }
 

--- a/source/danger/danger_runner.ts
+++ b/source/danger/danger_runner.ts
@@ -6,11 +6,13 @@ import { GitHubInstallationSettings } from "../db/GitHubRepoSettings"
 import { RootObject as PR } from "../github/events/types/pull_request_opened.types"
 
 import { getCISourceForEnv } from "danger/distribution/ci_source/get_ci_source"
+import { PerilDSL } from "danger/distribution/dsl/DangerDSL"
 import { DangerResults } from "danger/distribution/dsl/DangerResults"
 import { GitHub } from "danger/distribution/platforms/GitHub"
 import { GitHubAPI } from "danger/distribution/platforms/github/GitHubAPI"
 import { Executor, ExecutorOptions } from "danger/distribution/runner/Executor"
-import inlineRunner from "danger/distribution/runner/runners/vm2"
+import { DangerRunner } from "danger/distribution/runner/runners/runner"
+import vm2 from "danger/distribution/runner/runners/vm2"
 
 import * as NodeGithub from "@octokit/rest"
 
@@ -19,20 +21,14 @@ import * as path from "path"
 import * as write from "write-file-promise"
 import { dsl } from "./danger_run"
 
+import { getTemporaryAccessTokenForInstallation } from "api/github"
 import { contextForDanger, DangerContext } from "danger/distribution/runner/Dangerfile"
-import { getTemporaryAccessTokenForInstallation } from "../api/github"
 import { generateTaskSchedulerForInstallation } from "../tasks/scheduleTask"
+import { appendPerilContextToDSL, perilObjectForInstallation } from "./append_peril"
 import perilPlatform from "./peril_platform"
 
 /** Logs */
 const log = (message: string) => winston.info(`[runner] - ${message}`)
-
-// What does the Peril object look like inside the runtime
-// TODO: Expose this usefully somehow
-export interface PerilDSL {
-  // A list of accepted ENV vars into the peril runtime, configurable in settings.
-  env: any | false
-}
 
 export interface InstallationToRun {
   id: number
@@ -57,7 +53,7 @@ export async function runDangerForInstallation(
   const gh = api ? new GitHub(api) : null
   const platform = perilPlatform(type, gh, dangerDSL)
 
-  const exec = await executorForInstallation(platform)
+  const exec = await executorForInstallation(platform, vm2)
 
   const randomName = Math.random().toString(36)
   const localDangerfilePath = path.resolve("./" + "danger-" + randomName + path.extname(filepath))
@@ -65,18 +61,6 @@ export async function runDangerForInstallation(
 
   return await runDangerAgainstFile(localDangerfilePath, contents, installation, exec, peril, dangerDSL)
 }
-
-export const perilObjectForInstallation = (
-  installation: InstallationToRun,
-  environment: any,
-  peril: any
-): PerilDSL => ({
-  ...peril,
-  env:
-    installation.settings.env_vars &&
-    Object.assign({}, ...installation.settings.env_vars.map(k => ({ [k]: environment[k] }))),
-  runTask: generateTaskSchedulerForInstallation(installation.id),
-})
 
 /**
  * Sets up the custom peril environment and runs danger against a local file
@@ -97,7 +81,6 @@ export async function runDangerAgainstFile(
     await appendPerilContextToDSL(installation.id, runtimeEnv.sandbox, peril)
   }
 
-  // runtimeEnv.rquire.root = dangerfile_runtime_env
   let results: DangerResults
 
   try {
@@ -109,7 +92,7 @@ export async function runDangerAgainstFile(
 }
 
 /** Returns Markdown results to post if an exception is raised during the danger run */
-const resultsForCaughtError = (file: string, contents: string, error: Error): DangerResults => {
+export const resultsForCaughtError = (file: string, contents: string, error: Error): DangerResults => {
   const failure = `Danger failed to run \`${file}\`.`
   const errorMD = `## Error ${error.name}
 \`\`\`
@@ -143,7 +126,7 @@ export async function handleDangerResults(results: DangerResults, exec: Executor
 /**
  * Generates a Danger Executor based on the installation's context
  */
-export function executorForInstallation(platform: Platform) {
+export function executorForInstallation(platform: Platform, runner: DangerRunner) {
   // We need this for things like repo slugs, PR IDs etc
   // https://github.com/danger/danger-js/blob/master/source/ci_source/ci_source.js
 
@@ -166,23 +149,5 @@ export function executorForInstallation(platform: Platform) {
 
   const execConfig = {}
   // Source can be removed in the next release of Danger
-  return new Executor(source, platform, inlineRunner, config)
-}
-
-export async function appendPerilContextToDSL(installationID: number, sandbox: DangerContext, peril: PerilDSL) {
-  if (sandbox.danger && sandbox.danger.github) {
-    const token = await getTemporaryAccessTokenForInstallation(installationID)
-    const api = new NodeGithub()
-
-    api.authenticate({
-      token,
-      type: "integration",
-    })
-
-    sandbox.danger.github.api = api
-  }
-
-  // TODO: Add this to the Danger DSL in Danger, as an optional
-  const anySandbox = sandbox as any
-  anySandbox.peril = peril
+  return new Executor(source, platform, runner, config)
 }

--- a/source/danger/peril_platform.ts
+++ b/source/danger/peril_platform.ts
@@ -9,7 +9,7 @@ import { dsl } from "./danger_run"
  * however, an event like an issue comment or a user creation has no way to provide any kind of
  * feedback or DSL. To work around that we use the event provided by GitHub and provide it to Danger.
  */
-const getPerilPlatformForDSL = (type: dsl, github: GitHub | null, githubEvent: any): Platform => {
+export const getPerilPlatformForDSL = (type: dsl, github: GitHub | null, githubEvent: any): Platform => {
   if (type === dsl.pr && github) {
     return github
   } else {

--- a/source/github/events/_tests/_github_runner-events.test.ts
+++ b/source/github/events/_tests/_github_runner-events.test.ts
@@ -9,7 +9,7 @@ const mockGHContents = jest.fn((token, repo, path) => {
   }
 })
 
-jest.mock("../../../api/github", () => ({
+jest.mock("api/github", () => ({
   getTemporaryAccessTokenForInstallation: () => Promise.resolve("token"),
 }))
 jest.mock("../../../github/lib/github_helpers", () => ({

--- a/source/github/events/_tests/_github_runner-runs.test.ts
+++ b/source/github/events/_tests/_github_runner-runs.test.ts
@@ -57,6 +57,7 @@ it("handles a platform only run", () => {
       event: "pull_request",
       feedback: 0,
       repoSlug: "orta/peril-dangerfiles",
+      referenceString: "orta/peril-dangerfiles@pr.ts",
     },
   ])
 })
@@ -85,6 +86,7 @@ it("gets the expected runs for platform + repo rules", () => {
       event: "pull_request",
       feedback: 0,
       repoSlug: "orta/peril-dangerfiles",
+      referenceString: "orta/peril-dangerfiles@pr.ts",
     },
     {
       action: "created",
@@ -94,6 +96,7 @@ it("gets the expected runs for platform + repo rules", () => {
       event: "pull_request",
       feedback: 0,
       repoSlug: undefined,
+      referenceString: "pr.ts",
     },
   ])
 })
@@ -133,6 +136,7 @@ it("gets the expected runs for platform", () => {
       dslType: 1,
       event: "issues",
       feedback: 0,
+      referenceString: "pr.ts",
       repoSlug: undefined,
     },
   ])

--- a/source/github/events/createPRDSL.ts
+++ b/source/github/events/createPRDSL.ts
@@ -13,8 +13,17 @@ import { dsl } from "../../danger/danger_run"
  * @param githubAPI the Danger GithubAPI instance
  */
 export const createPRDSL = async (githubAPI: GitHubAPI) => {
+  const jsonDSL = await createPRJSONDSL(githubAPI)
+  return await jsonToDSL(jsonDSL)
+}
+
+/**
+ * Generates a full DSL for a PR
+ *
+ * @param githubAPI the Danger GithubAPI instance
+ */
+export const createPRJSONDSL = async (githubAPI: GitHubAPI) => {
   const gh = new GitHub(githubAPI)
   const platform = perilPlatform(dsl.pr, gh, {})
-  const jsonDSL = await jsonDSLGenerator(platform)
-  return await jsonToDSL(jsonDSL)
+  return await jsonDSLGenerator(platform)
 }

--- a/source/github/events/create_installation.ts
+++ b/source/github/events/create_installation.ts
@@ -2,7 +2,7 @@ import * as express from "express"
 
 import { Installation } from "../events/types/integration_installation_created.types"
 
-import { requestAccessTokenForInstallation } from "../../api/github"
+import { requestAccessTokenForInstallation } from "api/github"
 import { GitHubInstallation } from "../../db"
 import db from "../../db/getDB"
 

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -9,6 +9,8 @@ import { GitHubAPI } from "danger/distribution/platforms/github/GitHubAPI"
 import { jsonDSLGenerator } from "danger/distribution/runner/dslGenerator"
 import { jsonToDSL } from "danger/distribution/runner/jsonToDSL"
 
+import vm2 from "danger/distribution/runner/runners/vm2"
+
 import { getTemporaryAccessTokenForInstallation } from "api/github"
 import { DangerRun, dangerRunForRules, dsl, feedback } from "../../danger/danger_run"
 import { executorForInstallation, runDangerForInstallation } from "../../danger/danger_runner"
@@ -345,7 +347,7 @@ export const commentOnResults = async (dslType: dsl, results: DangerResults, tok
   const githubAPI = githubAPIForCommentable(token, settings.repoName, settings.commentableID)
   const gh = new GitHub(githubAPI)
   const platform = perilPlatform(dslType, gh, {})
-  const exec = executorForInstallation(platform)
+  const exec = executorForInstallation(platform, vm2)
   await exec.handleResults(results)
 }
 

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -11,6 +11,7 @@ import { jsonToDSL } from "danger/distribution/runner/jsonToDSL"
 
 import { getTemporaryAccessTokenForInstallation } from "api/github"
 import vm2 from "danger/distribution/runner/runners/vm2"
+import { resolve } from "dns"
 import { DangerRun, dangerRunForRules, dsl, feedback } from "../../danger/danger_run"
 import { executorForInstallation, runDangerForInstallation } from "../../danger/danger_runner"
 import perilPlatform from "../../danger/peril_platform"
@@ -201,7 +202,7 @@ export const runEventRun = async (
     settings: settings.installationSettings,
   }
 
-  return await runDangerForInstallation(
+  const results = await runDangerForInstallation(
     headDangerfile,
     run.referenceString,
     githubAPI,
@@ -209,6 +210,8 @@ export const runEventRun = async (
     installationSettings,
     { github: dangerDSL }
   )
+
+  return results || null
 }
 
 export const runPRRun = async (
@@ -312,10 +315,10 @@ ${JSON.stringify(stateForErrorHandling, null, "  ")}
       dangerDSL
     )
 
-    if (pr.body !== null && pr.body.includes("Peril: Debug")) {
+    if (results && pr.body !== null && pr.body.includes("Peril: Debug")) {
       results.markdowns.push(reportData("Showing PR details due to including 'Peril: Debug'"))
     }
-    return results
+    return results ? results : null
   }
 }
 

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -9,7 +9,7 @@ import { GitHubAPI } from "danger/distribution/platforms/github/GitHubAPI"
 import { jsonDSLGenerator } from "danger/distribution/runner/dslGenerator"
 import { jsonToDSL } from "danger/distribution/runner/jsonToDSL"
 
-import { getTemporaryAccessTokenForInstallation } from "../../api/github"
+import { getTemporaryAccessTokenForInstallation } from "api/github"
 import { DangerRun, dangerRunForRules, dsl, feedback } from "../../danger/danger_run"
 import { executorForInstallation, runDangerForInstallation } from "../../danger/danger_runner"
 import perilPlatform from "../../danger/peril_platform"

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -9,9 +9,8 @@ import { GitHubAPI } from "danger/distribution/platforms/github/GitHubAPI"
 import { jsonDSLGenerator } from "danger/distribution/runner/dslGenerator"
 import { jsonToDSL } from "danger/distribution/runner/jsonToDSL"
 
-import vm2 from "danger/distribution/runner/runners/vm2"
-
 import { getTemporaryAccessTokenForInstallation } from "api/github"
+import vm2 from "danger/distribution/runner/runners/vm2"
 import { DangerRun, dangerRunForRules, dsl, feedback } from "../../danger/danger_run"
 import { executorForInstallation, runDangerForInstallation } from "../../danger/danger_runner"
 import perilPlatform from "../../danger/peril_platform"
@@ -204,7 +203,7 @@ export const runEventRun = async (
 
   return await runDangerForInstallation(
     headDangerfile,
-    run.dangerfilePath,
+    run.referenceString,
     githubAPI,
     run.dslType,
     installationSettings,
@@ -306,7 +305,7 @@ ${JSON.stringify(stateForErrorHandling, null, "  ")}
     const dangerDSL = await createPRDSL(githubAPI)
     const results = await runDangerForInstallation(
       headDangerfile,
-      run.dangerfilePath,
+      run.referenceString,
       githubAPI,
       run.dslType,
       installationSettings,

--- a/source/github/lib/github_helpers.ts
+++ b/source/github/lib/github_helpers.ts
@@ -1,5 +1,6 @@
+import { getTemporaryAccessTokenForInstallation } from "api/github"
 import fetch from "../../api/fetch"
-import { getTemporaryAccessTokenForInstallation } from "../../api/github"
+import { RepresentationForURL } from "../../danger/danger_run"
 import { GitHubUser } from "../../db/types"
 import { PERIL_ORG_INSTALLATION_ID } from "../../globals"
 import winston from "../../logger"
@@ -9,6 +10,14 @@ export async function canUserWriteToRepo(token: string, user: string, repoSlug: 
   const req = await api(token, `repos/${repoSlug}/collaborators/${user}/permission`)
   const res = await req.json()
   return res.permission === "admin" || res.permission === "write"
+}
+
+export async function getGitHubFileContentsFromLocation(
+  token: string | null,
+  location: RepresentationForURL,
+  defaultRepo: string
+) {
+  return getGitHubFileContents(token, location.repoSlug || defaultRepo, location.dangerfilePath, location.branch)
 }
 
 /**

--- a/source/globals.ts
+++ b/source/globals.ts
@@ -85,6 +85,17 @@ export const PUBLIC_FACING_API = !!getEnv("PUBLIC_FACING_API")
 /** The URL for a Mongo DB instance, currently used for  */
 export const MONGODB_URI = getEnv("MONGODB_URI")
 
+/** Optional: the hyper access key, adding this will convert
+ *  Peril to run in a process separated mode.
+ */
+export const HYPER_ACCESS_KEY = getEnv("HYPER_ACCESS_KEY")
+
+/** Optional: the hyper secret key from hyper.sh. */
+export const HYPER_SECRET_KEY = getEnv("HYPER_SECRET_KEY")
+
+/** Optional: the function name that represents a danger run */
+export const HYPER_FUNC_NAME = getEnv("HYPER_FUNC_NAME")
+
 // Can't run without these
 validates(["PRIVATE_GITHUB_SIGNING_KEY", "PERIL_INTEGRATION_ID"])
 

--- a/source/runner/hyper-api.ts
+++ b/source/runner/hyper-api.ts
@@ -1,0 +1,33 @@
+import { HYPER_ACCESS_KEY, HYPER_FUNC_NAME, HYPER_SECRET_KEY } from "globals"
+import * as aws4 from "hyper-aws4"
+import fetch from "node-fetch"
+
+// For usage, check out these tests, https://github.com/Tim-Zhang/hyper-aws4/blob/master/test/unit.js
+
+// https://docs.hyper.sh/Reference/API/2016-04-04%20[Ver.%201.23]/Func/index.html
+
+export const hyper = (path: string, method: "GET" | "PUT" | "POST", body?: any) => {
+  const signOption: any = {
+    url: "https://us-west-1.hyper.sh/" + path,
+    method,
+    credential: {
+      accessKey: HYPER_ACCESS_KEY,
+      secretKey: HYPER_SECRET_KEY,
+    },
+  }
+
+  if (body) {
+    signOption.body = JSON.stringify(body)
+  }
+
+  const headers = aws4.sign(signOption)
+  const options: any = { method: signOption.method, headers }
+  return fetch(signOption.url).then(res => res.json())
+}
+
+// https://docs.hyper.sh/Reference/API/2016-04-04%20[Ver.%201.23]/Func/update.html
+export const callHyperFuncUpdate = () => hyper(`func/${HYPER_FUNC_NAME}`, "PUT")
+
+// https://docs.hyper.sh/Reference/API/2016-04-04%20[Ver.%201.23]/Func/call.html
+export const callHyperFunction = (uuid: string, body: any) =>
+  hyper(`func/call/${HYPER_FUNC_NAME}/${uuid}`, "POST", body)

--- a/source/runner/index.ts
+++ b/source/runner/index.ts
@@ -43,7 +43,7 @@ interface PerilRunnerObject {
 }
 
 /** This function is used inside Peril */
-const triggerSandboxDangerRun = async (
+export const triggerSandboxDangerRun = async (
   type: dsl,
   installationID: number,
   path: DangerfileReferenceString,
@@ -87,10 +87,12 @@ const run = async (stdin: string) => {
   const dslMode = input.dslType === "pr" ? dsl.pr : dsl.import
 
   if (dslMode === dsl.pr) {
-    runDangerPR(installation, input)
+    await runDangerPR(installation, input)
   } else {
-    runDangerEvent(installation, input)
+    await runDangerEvent(installation, input)
   }
+
+  return null
 }
 
 // There's a lot of redundnacy between these, but at least they're somewhat separated in their mental

--- a/source/runner/index.ts
+++ b/source/runner/index.ts
@@ -1,0 +1,171 @@
+import * as getSTDIN from "get-stdin"
+import * as nodeCleanup from "node-cleanup"
+import { extname, resolve } from "path"
+import uuid from "uuid/v1"
+
+import logger from "../logger"
+
+import { DangerDSLJSONType } from "danger/distribution/dsl/DangerDSL"
+import { DangerfileReferenceString, GitHubInstallation } from "../db/index"
+
+import { GitHub } from "danger/distribution/platforms/GitHub"
+import { contextForDanger } from "danger/distribution/runner/Dangerfile"
+import { jsonToDSL } from "danger/distribution/runner/jsonToDSL"
+import inlineRunner from "danger/distribution/runner/runners/inline"
+
+import { getTemporaryAccessTokenForInstallation } from "api/github"
+import { perilObjectForInstallation } from "../danger/append_peril"
+import { dangerRepresentationforPath, dsl } from "../danger/danger_run"
+import { executorForInstallation } from "../danger/danger_runner"
+import { getPerilPlatformForDSL } from "../danger/peril_platform"
+import db from "../db/getDB"
+import { getGitHubFileContents, getGitHubFileContentsFromLocation } from "../github/lib/github_helpers"
+
+import { HYPER_FUNC_NAME } from "globals"
+import { callHyperFunction } from "runner/hyper-api"
+
+interface PerilRunnerObject {
+  /** The DSL for JSON, could be a DangerDSLJSON type or the raw webhook */
+  dsl: DangerDSLJSONType // | any
+  /** The refernce for the initial dangerfile */
+  path: DangerfileReferenceString
+  /** github token */
+  token: string
+  /** Installation number */
+  installationID: number
+  /** DSL type */
+  dslType: "pr" | "run"
+  /** Optional Peril settings? (think like task) */
+  // TODO: Make a PerilJSONDSL
+  peril: any
+
+  // TODO: Validate the source came from Peril - public key based on the GH private one?
+}
+
+/** This function is used inside Peril */
+const triggerSandboxDangerRun = async (
+  type: dsl,
+  installationID: number,
+  path: DangerfileReferenceString,
+  dslJSON: any,
+  peril: any
+) => {
+  const token = await getTemporaryAccessTokenForInstallation(installationID)
+  const stdOUT: PerilRunnerObject = {
+    installationID,
+    dsl: dslJSON,
+    dslType: type === dsl.pr ? "pr" : "run",
+    token,
+    peril,
+    path,
+  }
+
+  const runUUID = uuid()
+  logger.info(`Calling hyper function with id ${runUUID}`)
+  const call = await callHyperFunction(runUUID, stdOUT)
+  logger.info(`Response: ${call}`)
+  if (call.CallId) {
+    logger.info(`Check logs via:`)
+    logger.info(`> hyper func logs ${HYPER_FUNC_NAME} --callid ${call.callID}`)
+  }
+}
+
+let foundDSL = false
+let runtimeEnv = {} as any
+
+const run = async (stdin: string) => {
+  foundDSL = true
+  logger.info("Got STDIN: " + stdin)
+
+  const input = JSON.parse(stdin) as PerilRunnerObject
+  const installation = await db.getInstallation(input.installationID)
+  if (!installation) {
+    logger.error("Could not find an installation")
+    return
+  }
+
+  const dslMode = input.dslType === "pr" ? dsl.pr : dsl.import
+
+  if (dslMode === dsl.pr) {
+    runDangerPR(installation, input)
+  } else {
+    runDangerEvent(installation, input)
+  }
+}
+
+// There's a lot of redundnacy between these, but at least they're somewhat separated in their mental
+// model, used to be much harder to keep track of their diffferences
+
+const runDangerEvent = async (installation: GitHubInstallation, input: PerilRunnerObject) => {
+  const token = await getTemporaryAccessTokenForInstallation(installation.id)
+
+  const platform = getPerilPlatformForDSL(dsl.import, null, input.dsl)
+  const exec = await executorForInstallation(platform, inlineRunner)
+
+  const randomName = Math.random().toString(36)
+  const localDangerfilePath = resolve("./" + "danger-" + randomName + "-event")
+
+  // Create a DSL that is basically just the webhook
+  // TODO: This probably needs expanding to the util funcs etc
+  const context = contextForDanger({ github: input.dsl } as any)
+  context.peril = perilObjectForInstallation(installation, process.env, input.peril)
+
+  const dangerfileLocation = dangerRepresentationforPath(input.path)
+  if (!dangerfileLocation.repoSlug) {
+    logger.error(`No repo slug in ${input.path} given for event based run, which is not supported yet`)
+    return
+  }
+
+  const dangerfile = await getGitHubFileContentsFromLocation(token, dangerfileLocation, dangerfileLocation.repoSlug!)
+
+  runtimeEnv = await inlineRunner.createDangerfileRuntimeEnvironment(context)
+  await inlineRunner.runDangerfileEnvironment(dangerfile, undefined, runtimeEnv)
+}
+
+const runDangerPR = async (installation: GitHubInstallation, input: PerilRunnerObject) => {
+  const token = await getTemporaryAccessTokenForInstallation(installation.id)
+
+  const platform = getPerilPlatformForDSL(dsl.pr, null, input.dsl)
+  const exec = await executorForInstallation(platform, inlineRunner)
+
+  const randomName = Math.random().toString(36)
+  const localDangerfilePath = resolve("./" + "danger-" + randomName + "-event")
+
+  const runtimeDSL = await jsonToDSL(input.dsl)
+  const context = contextForDanger(runtimeDSL)
+  context.peril = perilObjectForInstallation(installation, process.env, input.peril)
+
+  const dangerfileLocation = dangerRepresentationforPath(input.path)
+
+  const defaultRepoSlug = input.dsl.github.pr.base.repo.full_name
+  const dangerfile = await getGitHubFileContentsFromLocation(token, dangerfileLocation, defaultRepoSlug)
+
+  runtimeEnv = await inlineRunner.createDangerfileRuntimeEnvironment(context)
+  const results = await inlineRunner.runDangerfileEnvironment(dangerfile, undefined, runtimeEnv)
+  await exec.handleResultsPostingToPlatform(results)
+  logger.info("Done")
+}
+
+// Wait till the end of the process to print out the results. Will
+// only post the results when the process has succeeded, leaving the
+// host process to create a message from the logs.
+nodeCleanup((exitCode: number, signal: string) => {
+  logger.info(`Process has finished with ${exitCode} ${signal}, sending the results back to the host process`)
+  if (foundDSL) {
+    // TODO: Failure cases?
+    logger.info("TODO")
+    // runtimeEnv.results
+  }
+})
+
+// Add a timeout so that CI doesn't run forever if something has broken.
+setTimeout(() => {
+  if (!foundDSL) {
+    logger.error("Timeout: Failed to get the PerilRunnerObject after 1 second")
+    process.exitCode = 1
+    process.exit(1)
+  }
+}, 1000)
+
+// Start waiting on STDIN for the DSL
+getSTDIN().then(run)

--- a/source/scheduler/_tests/_runJob.test.ts
+++ b/source/scheduler/_tests/_runJob.test.ts
@@ -2,7 +2,7 @@ import { dsl } from "../../danger/danger_run"
 import { GitHubInstallation } from "../../db/index"
 import runJob from "../runJob"
 
-jest.mock("../../api/github", () => ({
+jest.mock("api/github", () => ({
   getTemporaryAccessTokenForInstallation: () => Promise.resolve("token123"),
 }))
 

--- a/source/scheduler/runJob.ts
+++ b/source/scheduler/runJob.ts
@@ -1,5 +1,5 @@
+import { getTemporaryAccessTokenForInstallation } from "api/github"
 import { scheduleJob } from "node-schedule"
-import { getTemporaryAccessTokenForInstallation } from "../api/github"
 import { dangerRepresentationforPath, dangerRunForRules, dsl } from "../danger/danger_run"
 import { runDangerForInstallation } from "../danger/danger_runner"
 import { DangerfileReferenceString, GitHubInstallation } from "../db/index"

--- a/source/tasks/runTask.ts
+++ b/source/tasks/runTask.ts
@@ -1,4 +1,4 @@
-import { getTemporaryAccessTokenForInstallation } from "../api/github"
+import { getTemporaryAccessTokenForInstallation } from "api/github"
 import { dangerRepresentationforPath, dangerRunForRules, dsl } from "../danger/danger_run"
 import { runDangerForInstallation } from "../danger/danger_runner"
 import { DangerfileReferenceString, GitHubInstallation } from "../db/index"

--- a/source/tasks/startTaskScheduler.ts
+++ b/source/tasks/startTaskScheduler.ts
@@ -39,12 +39,15 @@ export const startTaskScheduler = async () => {
     }
 
     const results = await runTask(installation, taskString, data.data)
-    if (!results.fails.length) {
-      logger.info("Task completed successfully")
-    } else {
-      logger.error("Task failed:")
-      logger.error(results.fails.map(f => f.message).join("\n"))
-      logger.error(results.markdowns.join("\n"))
+    // There aren't results when it's process separated
+    if (results) {
+      if (!results.fails.length) {
+        logger.info("Task completed successfully")
+      } else {
+        logger.error("Task failed:")
+        logger.error(results.fails.map(f => f.message).join("\n"))
+        logger.error(results.markdowns.join("\n"))
+      }
     }
     done()
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "lib": ["es2016", "es2016.array.include"],
     "sourceMap": true,
     "rootDir": "source",
+    "baseUrl": "source",
     "allowJs": true,
     "strictNullChecks": true
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,20 @@
     proxy-from-env "^1.0.0"
     url-template "^2.0.8"
 
+"@octokit/rest@^14.0.6":
+  version "14.0.6"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-14.0.6.tgz#92d18601ecc346b0349ad4a3219ccc5bc00e6254"
+  dependencies:
+    before-after-hook "^1.1.0"
+    debug "^3.1.0"
+    dotenv "^4.0.0"
+    https-proxy-agent "^2.1.0"
+    is-array-buffer "^1.0.0"
+    is-stream "^1.1.0"
+    lodash "^4.17.4"
+    proxy-from-env "^1.0.0"
+    url-template "^2.0.8"
+
 "@types/agenda@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/agenda/-/agenda-1.0.1.tgz#9b309d634c30e7634f192f2e530f303684298f17"
@@ -1849,9 +1863,9 @@ danger-plugin-yarn@^1.2.1:
   optionalDependencies:
     esdoc "^0.5.2"
 
-danger@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/danger/-/danger-3.1.0.tgz#91760945b641d3a17720d3fa27d3c68dac6a0656"
+danger@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/danger/-/danger-3.1.3.tgz#34c0526d893001d5fe611ad57035e66ad31eca63"
   dependencies:
     "@octokit/rest" "^14.0.4"
     babel-polyfill "^6.23.0"
@@ -2955,6 +2969,12 @@ husky@^0.14.0:
     normalize-path "^1.0.0"
     strip-indent "^2.0.0"
 
+hyper-aws4@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/hyper-aws4/-/hyper-aws4-1.1.3.tgz#c1882e746af5445d065a941df22ed165e332bdd7"
+  dependencies:
+    lodash "^4.13.1"
+
 hyperlinker@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hyperlinker/-/hyperlinker-1.0.0.tgz#23dc9e38a206b208ee49bc2d6c8ef47027df0c0e"
@@ -3057,6 +3077,10 @@ is-absolute@^0.2.3:
   dependencies:
     is-relative "^0.2.1"
     is-windows "^0.2.0"
+
+is-array-buffer@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-array-buffer/-/is-array-buffer-1.0.0.tgz#f32497a0509d109423f472003f98bab6a8ea34cb"
 
 is-arrayish@^0.2.1:
   version "0.2.1"


### PR DESCRIPTION
Re: https://github.com/danger/peril/issues/159 https://github.com/danger/danger/issues/42
Deprecates: #183  

This sets up Peril to be able to run a Dangerfile inside a [hyper](https://hyper.sh) [function](https://docs.hyper.sh/Feature/container/func.html) instead of executing in the same server/process. Allowing safe, scalable execution of unsafe code. 

### Before

* GH sends webhook to Peril
* Webhook is routed internally and could trigger some dangerfile runs
* Inside Peril the Danger DSL is set up and then executed via [vm2](https://github.com/patriksimek/vm2)

This is fine for trusted code, but it's not doable when dealing with code you really want to not screw up your machine. This has lead me down many paths 👍

AWS Lamda was a great first start, but it turned out to have an issue in that the runtime would allow data to leak between runs. You could _fix_ it by crashing the vm at the end of a run, but you'd need to boot the vm up again on the next run and that's pretty slow. 

So I let it sit until I discovered hyper, which is a service where you give them a docker container and the will host and start it up in ~5s when it's inactive. I spent yesterday with @lazerwalker  going through the full process of hosting a node app on hyper to understand all of the pieces.

Once familiar, I looked into how hyper funcs worked. You pass it a docker container and they set up an extremely fast booting VM which you can execute CLI commands against. It has an API which will take whatever you send and pass in via STDIN. Which is basically how [danger process](http://danger.systems/js/usage/danger-process.html) works.

So this PR adds a new script which is executable, `node dist/runner/index.js` which expects a certain JSON input to STDIN and will handle the execution of a dangerfile in the same way that the danger-runner CLI tool will. This means no more `schedule`, and real process/server separation.

### After

* GH sends webhook to Peril
* Webhook is routed internally and could trigger some dangerfile runs
* Peril checks the ENV vars and *either*
  * Uses the hyper API to trigger a run on a free VM 
  * Executes in-process via [vm2](https://github.com/patriksimek/vm2)

This means that #185 is actually feasible, if someone set up a docker container for running from the JSON given from Peril. 

So, basically, once this is solid, I can start moving some of our existing peril installations (artsy/cocoapods/danger) into clients on a main staging peril. Making it the foundation of eventually being able to allow anyone to sign up to Peril.
