### PR TITLE
Fix crash when a non-repo event is passed to runPRRun

### DIFF
--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -229,13 +229,17 @@ export const runPRRun = async (
     return null
   }
 
+  if (!pr.head.repo) {
+    console.error("An event without a head repo was passed to runPRRun") // tslint:disable-line
+    return null
+  }
+
   const githubAPI = githubAPIForCommentable(token, settings.repoName, settings.commentableID)
 
   // In theory only a PR requires a custom branch, so we can check directly for that
   // in the event JSON and if it's not there then use master
   // prioritise the run metadata
 
-  // TODO: this check can crash during a non-repo event
   const dangerfileRepoForPR = pr.head.repo.full_name
   const dangerfileBranchForPR = pr.head.ref
   const neededDangerfileIsLocalRepo = !run.repoSlug


### PR DESCRIPTION
closes #204 

Playing around with learning typescript this weekend and thought I would do some hacking on open peril issues.

This fixes the crash by adding a defensive return and logging the error. A potential future improvement would be doing some earlier validation and selection of events, but I'm not :100: on the javascript conventions around this (and a similar pattern is already used in the run*run fns).