### PR TITLE
Remove the body param from api requests if it's a GET/HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
-node_js: 8
+node_js: 8.9
 cache: yarn

--- a/source/github/lib/github_helpers.ts
+++ b/source/github/lib/github_helpers.ts
@@ -81,8 +81,9 @@ async function api(token: string | null, path: string, headers: any = {}, body: 
   }
 
   const baseUrl = process.env.DANGER_GITHUB_API_BASE_URL || "https://api.github.com"
+  const includeBody = !(method === "GET" || method === "HEAD")
   return fetch(`${baseUrl}/${path}`, {
-    body,
+    body: includeBody ? body : undefined,
     headers: {
       Accept: "application/vnd.github.machine-man-preview+json",
       "Content-Type": "application/json",


### PR DESCRIPTION
Looks like an update to the fetch dependency broke this in prod but not in tests.