### PR TITLE
Fix Dangerfile on branch

### DIFF
--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -194,7 +194,7 @@ export const runEventRun = async (
     githubAPI = githubAPIForCommentable(token, settings.repoName, settings.commentableID)
   }
 
-  const headDangerfile = await getGitHubFileContents(token, repoForDangerfile, run.dangerfilePath, null)
+  const headDangerfile = await getGitHubFileContents(token, repoForDangerfile, run.dangerfilePath, run.branch)
 
   const installationSettings = {
     id: settings.installationID,


### PR DESCRIPTION
This fixes the "Cannot find dangerfile" error from #223, but the "regeneratorRuntime is not defined" error persists.