### PR TITLE
Improve the types used in common testing scenarios

### DIFF
--- a/source/api/auth/github.ts
+++ b/source/api/auth/github.ts
@@ -36,7 +36,7 @@ export const generateAuthToken = async (req: Request, res: Response, ___: NextFu
 
   const { error, error_description, error_uri } = req.query
   if (error) {
-    res.send(400, { error, error_description, error_uri })
+    res.status(400).send({ error, error_description, error_uri })
     return
   }
 
@@ -44,14 +44,14 @@ export const generateAuthToken = async (req: Request, res: Response, ___: NextFu
   // Set that to the user's session, and then redirect to the admin page
   const { code, state } = req.query
   if (state !== PERIL_WEBHOOK_SECRET) {
-    res.send(400, { error: "Bad state", error_description: "The state query param was incorrect" })
+    res.status(400).send({ error: "Bad state", error_description: "The state query param was incorrect" })
     return
   }
 
   const token = await getAccessTokenFromAuthCode(code)
   if (!token) {
     if (error) {
-      res.send(400, { error: "Could not generate an access token from the code given from GitHub" })
+      res.status(400).send({ error: "Could not generate an access token from the code given from GitHub" })
       return
     }
   }
@@ -62,7 +62,7 @@ export const generateAuthToken = async (req: Request, res: Response, ___: NextFu
 
   const authToken = createPerilJWT({ name: user.name, avatar_url: user.avatar_url }, installations)
   res.cookie("jwt", authToken)
-  res.send(200, { jwt: authToken })
+  res.status(200).send({ jwt: authToken })
 }
 
 const getAccessTokenFromAuthCode = async (code: string) => {

--- a/source/db/__mocks__/getDB.ts
+++ b/source/db/__mocks__/getDB.ts
@@ -1,0 +1,40 @@
+import { DatabaseAdaptor, GitHubInstallation } from ".."
+
+// Caches per test file, so you can import it and check from the import
+// If this is an issue, don't use this mock :D
+let perTestFileMock: MockDB
+
+// A set of type alias' to make the below code readable.
+type NullFunc = () => Promise<void>
+type InstallationIDToNullInstallation = (installationID: number) => Promise<GitHubInstallation | null>
+type InstallationIDToInstallation = (installationID: number) => Promise<GitHubInstallation>
+type InstallationToVoid = (installationID: number) => Promise<void>
+
+// Take the DB and rewrite all of its functions to be both the original version and potentially the
+// jest mocked version of it.
+export interface MockDB extends DatabaseAdaptor {
+  setup: NullFunc & jest.Mock<NullFunc>
+  getInstallation: InstallationIDToNullInstallation & jest.Mock<InstallationIDToNullInstallation>
+  updateInstallation: InstallationIDToNullInstallation & jest.Mock<InstallationIDToNullInstallation>
+  saveInstallation: InstallationIDToInstallation & jest.Mock<InstallationIDToNullInstallation>
+  deleteInstallation: InstallationToVoid & jest.Mock<InstallationToVoid>
+}
+
+// Returns a MockDB which you'll have to alias to alas, because the type system doesn't know
+// that jest's mocking system will return a MockDB instead of a typical DatabaseAdaptor
+
+export const getDB = (): MockDB => {
+  if (perTestFileMock) {
+    return perTestFileMock
+  }
+
+  perTestFileMock = {
+    getInstallation: jest.fn(),
+    deleteInstallation: jest.fn(),
+    saveInstallation: jest.fn(),
+    updateInstallation: jest.fn(),
+    setup: jest.fn(),
+  }
+
+  return perTestFileMock
+}

--- a/source/routing/_tests/create-mock-response.ts
+++ b/source/routing/_tests/create-mock-response.ts
@@ -1,0 +1,8 @@
+import { Response } from "express"
+
+export const createMockResponse = () => {
+  const res = jest.fn() as jest.Mock<Response> & Response
+  res.status = jest.fn(() => res)
+  res.send = jest.fn()
+  return res
+}

--- a/source/runner/triggerSandboxRun.ts
+++ b/source/runner/triggerSandboxRun.ts
@@ -60,7 +60,6 @@ export const triggerSandboxDangerRun = async (
   }
 
   logger.info(`Calling hyper function`)
-  logger.info("JSON Sent: ", JSON.stringify(stdOUT, null, "  "))
 
   const call = await callHyperFunction(stdOUT)
   const callID = JSON.parse(call).CallId

--- a/yarn.lock
+++ b/yarn.lock
@@ -7732,9 +7732,9 @@ ts-jest@^22.4.1:
     pkg-dir "^2.0.0"
     yargs "^11.0.0"
 
-ts-node@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-5.0.1.tgz#78e5d1cb3f704de1b641e43b76be2d4094f06f81"
+ts-node@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-6.0.0.tgz#46c25f8498593a9248eeea16906f1598fa098140"
   dependencies:
     arrify "^1.0.0"
     chalk "^2.3.0"


### PR DESCRIPTION
I wanted to make it easier to test the db and requests, and most of the time to pull that off you have to use a bunch of `as any`s which isn't great IMO. 

This uses TypeScript's interface merging to let tests treat an object as both the original object, and a mocked version of it, so you're fine to do `x.y`, use x when it's expected `thing(x)` and also fine to do `x.mockImplementationOnce`.