### PR TITLE
Ensure the Peril Platform object conforms to the Platform interface

### DIFF
--- a/source/danger/peril_platform.ts
+++ b/source/danger/peril_platform.ts
@@ -22,9 +22,24 @@ export const getPerilPlatformForDSL = (type: dsl, github: GitHub | null, githubE
     }
 
     const nullFunc: any = () => ""
-    const platform: Platform | any = {
+    const platform: Platform = {
+      name: "Peril",
+      getFileContents: github ? github.getFileContents.bind(github) : nullFunc,
+
       createComment: github ? github.createComment.bind(github) : nullFunc,
       deleteMainComment: github ? github.deleteMainComment.bind(github) : nullFunc,
+      updateOrCreateComment: github ? github.updateOrCreateComment.bind(github) : nullFunc,
+
+      createInlineComment: github ? github.createInlineComment.bind(github) : nullFunc,
+      updateInlineComment: github ? github.updateInlineComment.bind(github) : nullFunc,
+      deleteInlineComment: github ? github.deleteInlineComment.bind(github) : nullFunc,
+      getInlineComments: () => (github ? github.getInlineComments.bind(github) : nullFunc),
+
+      supportsCommenting: () => (github ? github.supportsCommenting.bind(github) : nullFunc),
+      supportsInlineComments: () => (github ? github.supportsInlineComments.bind(github) : nullFunc),
+
+      updateStatus: () => (github ? github.supportsInlineComments.bind(github) : nullFunc),
+
       getPlatformDSLRepresentation: async () => {
         return {
           ...githubEvent,
@@ -32,13 +47,9 @@ export const getPerilPlatformForDSL = (type: dsl, github: GitHub | null, githubE
           utils,
         }
       },
-      supportsInlineComments: () => false,
       getPlatformGitRepresentation: async () => {
         return {} as any
       },
-      name: "Peril",
-      updateOrCreateComment: github ? github.updateOrCreateComment.bind(github) : nullFunc,
-      updateStatus: () => Promise.resolve(true),
     }
     return platform
   }


### PR DESCRIPTION
Fixes https://spectrum.chat/thread/11afe364-3289-4421-a9c8-f9ff554bd24b

Basically the Peril platform was a `Platform | any` which meant that it would get out of sync from reality without being type-checked, this fixes that.