### PR TITLE
Initial implementation for recording all webhooks for 5m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 2018 - April 28
 
+* Adds initial support for recording all Webhooks going to an installation for 5 minutes - orta (idea from ashfurrow)
 * Refactored a bunch of disparate event based routing into "plugins" still some better abstractions to go there but this
   is a good start - orta/pedrovereza
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "type-check": "tsc --noEmit --pretty",
     "postinstall": "yarn build; if [ $DATABASE_JSON_FILE ]; then yarn run setup; fi",
     "test": "jest && tslint source/**/**/**.ts",
+    "lint": " tslint source/**/**/**.ts",
     "generate:types:json": "ts-node source/scripts/json-types.ts && tslint source/**/*.ts --fix",
     "setup": "yarn run setup:plugins && yarn run setup:env",
     "setup:env": "node out/scripts/setup-env.js",

--- a/source/api/_tests/fixtureAPI.ts
+++ b/source/api/_tests/fixtureAPI.ts
@@ -15,9 +15,9 @@ const requestWithFixturedJSON = (path: string): (() => Promise<any>) => () =>
 const requestWithFixturedContent = (path: string): (() => Promise<string>) => () =>
   Promise.resolve(readFileSync(`${githubFixtures}/${path}`, {}).toString())
 
-/** Returns a fxitured GitHub instance */
+/** Returns a fixtured GitHub instance */
 
-export default (repoSlug?: string, pullRequestID?: string): GitHub => {
+export const fixturedAPI = (repoSlug?: string, pullRequestID?: string): GitHub => {
   repoSlug = repoSlug || "artsy/emission"
   pullRequestID = pullRequestID || "1"
   const api = new GitHubAPI({ repoSlug, pullRequestID }, "ABCDE")

--- a/source/api/api.ts
+++ b/source/api/api.ts
@@ -8,7 +8,7 @@ import { getJWTFromRequest } from "./auth/getJWTFromRequest"
 import { fakeAuthToken, generateAuthToken, redirectForGHOauth } from "./auth/github"
 import { schema } from "./graphql"
 import { redirectForGHInstallation } from "./integration/github"
-import prDSLRunner from "./pr/dsl"
+import { prDSLRunner } from "./pr/dsl"
 
 export const GitHubOAuthStart = "/api/auth/peril/github/start"
 export const GitHubOAuthEnd = "/api/auth/peril/github/end"
@@ -18,7 +18,7 @@ export interface GraphQLContext {
 }
 
 // Public API
-const setupPublicAPI = (app: Application) => {
+export const setupPublicAPI = (app: Application) => {
   // MISC
   // Generate a JSON DSL for any random PR
   app.get("/api/v1/pr/dsl", prDSLRunner)
@@ -54,5 +54,3 @@ const setupPublicAPI = (app: Application) => {
 
   app.use("/api/graphiql", graphiqlExpress({ endpointURL: "/api/graphql" }))
 }
-
-export default setupPublicAPI

--- a/source/api/pr/dsl.ts
+++ b/source/api/pr/dsl.ts
@@ -11,7 +11,7 @@ import { getPerilPlatformForDSL } from "../../danger/peril_platform"
 import { githubAPIForCommentable } from "../../github/events/utils/commenting"
 import { PERIL_ORG_INSTALLATION_ID } from "../../globals"
 
-const prDSLRunner = async (req: express.Request, res: express.Response, _: express.NextFunction) => {
+export const prDSLRunner = async (req: express.Request, res: express.Response, _: express.NextFunction) => {
   winston.log("router", `Received OK`)
 
   const query = req.query
@@ -58,5 +58,3 @@ const prDSLRunner = async (req: express.Request, res: express.Response, _: expre
     status: "OK",
   })
 }
-
-export default prDSLRunner

--- a/source/danger/_tests/_danger_runner.test.ts
+++ b/source/danger/_tests/_danger_runner.test.ts
@@ -3,7 +3,7 @@ import vm2 from "danger/distribution/runner/runners/vm2"
 import { readFileSync } from "fs"
 import { resolve } from "path"
 
-import fixturedGitHub from "../../api/_tests/fixtureAPI"
+import { fixturedAPI } from "../../api/_tests/fixtureAPI"
 import { perilObjectForInstallation } from "../../danger/append_peril"
 import { GitHubInstallationSettings } from "../../db/GitHubRepoSettings"
 import { executorForInstallation, runDangerAgainstFileInline } from "../danger_runner"
@@ -33,7 +33,7 @@ global.regeneratorRuntime = {}
 
 describe("evaling", () => {
   it("runs a typescript dangerfile with fixtured data", async () => {
-    const platform = fixturedGitHub()
+    const platform = fixturedAPI()
     const executor = executorForInstallation(platform, vm2)
     const contents = readFileSync(`${dangerfilesFixtures}/dangerfile_empty.ts`, "utf8")
     const results = await runDangerAgainstFileInline(
@@ -53,7 +53,7 @@ describe("evaling", () => {
   })
 
   it("highlights some of the security measures", async () => {
-    const platform = fixturedGitHub()
+    const platform = fixturedAPI()
     const executor = executorForInstallation(platform, vm2)
     const path = `${dangerfilesFixtures}/dangerfile_insecure.ts`
     const contents = readFileSync(path, "utf8")
@@ -72,7 +72,7 @@ describe("evaling", () => {
   // Wallaby can't resolve these
   if (!process.env.WALLABY_PRODUCTION) {
     it("allows external modules", async () => {
-      const platform = fixturedGitHub()
+      const platform = fixturedAPI()
       const executor = executorForInstallation(platform, vm2)
       const path = `${dangerfilesFixtures}/dangerfile_import_module.ts`
 
@@ -89,7 +89,7 @@ describe("evaling", () => {
     })
 
     it("allows external modules with internal resolving ", async () => {
-      const platform = fixturedGitHub()
+      const platform = fixturedAPI()
       const executor = executorForInstallation(platform, vm2)
 
       const localDangerfile = resolve("./dangerfile_runtime_env", "dangerfile_import_complex_module.ts")
@@ -108,7 +108,7 @@ describe("evaling", () => {
   }
 
   it("has a peril object defined in global scope", async () => {
-    const platform = fixturedGitHub()
+    const platform = fixturedAPI()
     const executor = executorForInstallation(platform, vm2)
 
     const localDangerfile = resolve(`${dangerfilesFixtures}/dangerfile_peril_obj.ts`)
@@ -127,7 +127,7 @@ describe("evaling", () => {
 
   // I wonder if the babel setup isn't quite right yet for this test
   it.skip("runs a JS dangerfile with fixtured data", async () => {
-    const platform = fixturedGitHub()
+    const platform = fixturedAPI()
     const executor = executorForInstallation(platform, vm2)
     // The executor will return results etc in the next release
     const path = `${dangerfilesFixtures}/dangerfile_insecure.ts`
@@ -150,7 +150,7 @@ describe("evaling", () => {
   })
 
   it("generates the correct modified/deleted/created paths", async () => {
-    const platform = fixturedGitHub()
+    const platform = fixturedAPI()
     const executor = executorForInstallation(platform, vm2)
     const dsl = await executor.dslForDanger()
     expect(dsl.git.created_files.length).toBeGreaterThan(0)

--- a/source/db/_tests/_json.test.ts
+++ b/source/db/_tests/_json.test.ts
@@ -19,7 +19,7 @@ jest.mock("../../github/lib/github_helpers", () => ({
 }))
 
 import { DatabaseAdaptor } from "../index"
-import jsonDB from "../json"
+import { jsonDatabase } from "../json"
 
 describe("makes the right calls to GitHub", () => {
   let db: DatabaseAdaptor = null as any
@@ -27,7 +27,7 @@ describe("makes the right calls to GitHub", () => {
   const setup = async () => {
     mockGHContents.mockImplementationOnce(() => Promise.resolve(legitSettings))
 
-    db = jsonDB("orta/peril@settings.json")
+    db = jsonDatabase("orta/peril@settings.json")
     return db.setup()
   }
 
@@ -44,7 +44,7 @@ it("Raises with a bad URL", async () => {
   expect.assertions(1)
 
   try {
-    const db = jsonDB("orta/other@settings.json")
+    const db = jsonDatabase("orta/other@settings.json")
     await db.setup()
   } catch (error) {
     expect(error).toMatchSnapshot()

--- a/source/db/getDB.ts
+++ b/source/db/getDB.ts
@@ -1,22 +1,22 @@
-import jsonDB from "./json"
-import mongo from "./mongo"
+import { jsonDatabase } from "./json"
+import { mongoDatabase } from "./mongo"
 
 import { DatabaseAdaptor } from "."
 
 const isJest = typeof jest !== "undefined"
 
-const getDatabaseForEnv = (env: any) => {
+const getDatabaseForEnv = (env: any): DatabaseAdaptor | null => {
   if (env.DATABASE_JSON_FILE || isJest) {
-    const json = jsonDB(env.DATABASE_JSON_FILE)
+    const json = jsonDatabase(env.DATABASE_JSON_FILE)
     json.setup()
     return json
   }
 
   if (env.MONGODB_URI) {
     if (!isJest) {
-      mongo.setup()
+      mongoDatabase.setup()
     }
-    return mongo
+    return mongoDatabase
   }
 
   return null

--- a/source/db/json.ts
+++ b/source/db/json.ts
@@ -32,7 +32,7 @@ const error = (message: string) => winston.error(`[json db] - ${message}`)
 
 let org: GitHubInstallation = null as any
 
-const jsonDatabase = (dangerFilePath: DangerfileReferenceString): DatabaseAdaptor => ({
+export const jsonDatabase = (dangerFilePath: DangerfileReferenceString): DatabaseAdaptor => ({
   /** Gets an Integration */
   getInstallation: async (_: number): Promise<GitHubInstallation | null> => {
     return org
@@ -100,8 +100,6 @@ export const partialInstallationToInstallation = (
     modules: (partial.settings && partial.settings.modules) || [],
   },
 })
-
-export default jsonDatabase
 
 const throwNoJSONFileFound = (dangerFilePath: DangerfileReferenceString) => {
   const msg = "Could not find find a JSON file for Peril settings."

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -223,5 +223,3 @@ export const mergeResults = (results: DangerResults[]): DangerResults => {
     { fails: [], markdowns: [], warnings: [], messages: [] }
   )
 }
-
-export default githubDangerRunner

--- a/source/index.ts
+++ b/source/index.ts
@@ -2,7 +2,7 @@ import * as cluster from "cluster"
 import * as os from "os"
 
 import logger from "./logger"
-import peril from "./peril"
+import { peril } from "./peril"
 
 const WORKERS = process.env.NODE_ENV === "production" ? process.env.WEB_CONCURRENCY || os.cpus().length : 1
 const log = (message: string) => {

--- a/source/peril.ts
+++ b/source/peril.ts
@@ -18,7 +18,7 @@ import {
 } from "./globals"
 
 import { URL } from "url"
-import setupPublicAPI from "./api/api"
+import { setupPublicAPI } from "./api/api"
 import logger from "./logger"
 import { hyperUpdater } from "./routing/hyper_updater"
 import { githubRouter } from "./routing/router"
@@ -29,7 +29,7 @@ const welcomeMessages = [] as string[]
 const tick = chalk.bold.greenBright("✓")
 const cross = chalk.bold.redBright("ⅹ")
 
-const peril = () => {
+export const peril = () => {
   validateENVForPerilServer()
 
   // Error logging
@@ -97,5 +97,3 @@ const peril = () => {
     startScheduler()
   })
 }
-
-export default peril

--- a/source/plugins/recordWebhooks.ts
+++ b/source/plugins/recordWebhooks.ts
@@ -1,0 +1,26 @@
+import * as express from "express"
+import { getDB } from "../db/getDB"
+import { MongoGithubInstallationModel } from "../db/mongo"
+import { recordWebhookWithRequest } from "./utils/recordWebhookWithRequest"
+
+export const recordWebhook = async (_: string, req: express.Request, __: express.Response, ___: any) => {
+  const installationID = req.body.installation.id as number
+  const db = getDB()
+  const installation = await db.getInstallation(installationID)
+
+  // Only deal with mongo installations, not JSON ones
+  if (!installation || !("recordWebhooksUntilTime" in installation)) {
+    return
+  }
+
+  const mongoInstallation = installation as MongoGithubInstallationModel
+  if (!mongoInstallation.recordWebhooksUntilTime) {
+    return
+  }
+
+  // If the time is in the future, then record the webhooks
+  const recordExpirationDateIsFuture = mongoInstallation.recordWebhooksUntilTime > new Date()
+  if (recordExpirationDateIsFuture) {
+    recordWebhookWithRequest(req)
+  }
+}

--- a/source/plugins/utils/recordWebhookWithRequest.ts
+++ b/source/plugins/utils/recordWebhookWithRequest.ts
@@ -1,0 +1,64 @@
+import * as express from "express"
+import { Document, model, Schema } from "mongoose"
+import { getDB } from "../../db/getDB"
+import { MongoDB } from "../../db/mongo"
+import { actionForWebhook } from "../../github/events/utils/actions"
+
+interface RecordedWebhook {
+  iID: number
+  event: string
+  eventID: string
+  createdAt: Date
+  json: any
+}
+
+// So that we can be sure of the model at runtime
+interface RecordedWebhookModel extends RecordedWebhook, Document {}
+
+const RecordedWebhook = model<RecordedWebhookModel>(
+  "RecordedWebhook",
+  new Schema({
+    iID: Number,
+    event: String,
+    json: Schema.Types.Mixed,
+  })
+)
+
+/** Takes any webhook and stores it into the DB */
+export const recordWebhookWithRequest = async (req: express.Request) => {
+  const installationID = req.body.installation.id as number
+  const event = req.header("X-GitHub-Event")
+  const eventID = req.header("X-GitHub-Delivery")
+  const action = actionForWebhook(req.body)
+  const eventName = action ? `${event}.${action}` : event
+
+  const record: RecordedWebhook = {
+    iID: installationID,
+    event: eventName,
+    eventID,
+    createdAt: new Date(),
+    json: req.body,
+  }
+
+  RecordedWebhook.create(record)
+}
+
+/** Triggers the recording time for a specific installation to be for the next 5m */
+export const setInstallationToRecord = async (installationID: number) => {
+  const db = getDB() as MongoDB
+  const inFiveMin = new Date(new Date().getTime() + 5 * 60000)
+  await db.saveInstallation({
+    iID: installationID,
+    recordWebhooksUntilTime: inFiveMin,
+  })
+}
+
+/** Removes all recorded webhooks for a specific installation */
+export const wipeAllRecordedWebhooks = async (installationID: number) => RecordedWebhook.remove({ iID: installationID })
+
+/** Brings back a bunch of webhooks, basically everything but the json payload */
+export const getRecordedWebhooksForInstallation = async (installationID: number) =>
+  RecordedWebhook.find({ iID: installationID }, "iID event eventID createdAt")
+
+/** Gets an webhook */
+export const getRecordedWebhook = async (eventID: string) => RecordedWebhook.find({ eventID })

--- a/source/plugins/utils/recordWebhookWithRequest.ts
+++ b/source/plugins/utils/recordWebhookWithRequest.ts
@@ -21,6 +21,8 @@ const RecordedWebhook = model<RecordedWebhookModel>(
     iID: Number,
     event: String,
     json: Schema.Types.Mixed,
+    eventID: String,
+    createdAt: Date,
   })
 )
 

--- a/source/routing/router.ts
+++ b/source/routing/router.ts
@@ -17,6 +17,11 @@ export const githubRouter = (req: Request, res: Response, next: NextFunction) =>
   githubDangerRunner(event, req, res, next)
 }
 
+// TODO:
+//   Type the plugins
+//   Make a context obj with installation and others
+//   Remove the next fn
+
 export const githubEventPluginHandler = (event: string, req: Request, res: Response, next: NextFunction) => {
   // Use XHub to verify the request was sent from GH
   if (!validatesGithubWebhook(event, req, res, next)) {

--- a/source/routing/router.ts
+++ b/source/routing/router.ts
@@ -5,6 +5,7 @@ import { githubDangerRunner } from "../github/events/github_runner"
 
 import { installationLifeCycle } from "../plugins/installationLifeCycle"
 import { installationSettingsUpdater } from "../plugins/installationSettingsUpdater"
+import { recordWebhook } from "../plugins/recordWebhooks"
 import { validatesGithubWebhook } from "../plugins/validatesGithubWebhook"
 
 export const githubRouter = (req: Request, res: Response, next: NextFunction) => {
@@ -29,6 +30,9 @@ export const githubEventPluginHandler = (event: string, req: Request, res: Respo
   }
   // Creating / Removing installations from the DB
   installationLifeCycle(event, req, res, next)
+
+  // Allow a dev mode
+  recordWebhook(event, req, res, next)
 
   // Updating an install when the JSON changes
   installationSettingsUpdater(event, req, res, next)

--- a/source/scripts/setup-plugins.ts
+++ b/source/scripts/setup-plugins.ts
@@ -1,6 +1,6 @@
 import * as child_process from "child_process"
 
-import jsonDatabase from "../db/json"
+import { jsonDatabase } from "../db/json"
 import { DATABASE_JSON_FILE } from "../globals"
 
 const log = console.log

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     // "no-default-export": true,
     "object-literal-sort-keys": false,
-    "interface-name": [true, "never-prefix"]
+    "interface-name": [true, "never-prefix"],
+    "no-default-export": true
   }
 }


### PR DESCRIPTION
This allows you to send a mutation requesting 5m of webhooks to be recorded, these are stored in the db and are wiped every time you request a new one.

Also starts to remove all default exports.