### PR TITLE
Adds Moya and RxSwiftCommunity repos.

### DIFF
--- a/docs/setup_for_org.md
+++ b/docs/setup_for_org.md
@@ -152,6 +152,8 @@ import { warn, danger } from "danger"
 * <https://github.com/danger/peril-settings>
 * <https://github.com/artsy/artsy-danger>
 * <https://github.com/CocoaPods/peril-settings>
+* <https://github.com/Moya/moya-peril>
+* <https://github.com/RxSwiftCommunity/peril>
 
 # Troubleshooting
 


### PR DESCRIPTION
This PR adds Peril settings repos for @Moya and @RxSwiftCommunity. I can add https://github.com/ashfurrow/peril-settings too, but it's a personal server instead of an organization one, and it might raise more questions than it answers. Up to you!