### PR TITLE
[WIP] Allow label names in labeled/unlabeled actions

### DIFF
--- a/source/danger/_tests/_danger_run.test.ts
+++ b/source/danger/_tests/_danger_run.test.ts
@@ -156,7 +156,7 @@ describe("for PRs", () => {
 describe("for label events", () => {
   it("returns a run for a labeled event with a matching label name", () => {
     const rules = {
-      "pull_request.labeled.question": "dangerfile.js",
+      "pull_request.labeled(question)": "dangerfile.js",
     }
     const body = {
       action: "labeled",
@@ -182,7 +182,7 @@ describe("for label events", () => {
 
   it("returns null when no label names match", () => {
     const rules = {
-      "pull_request.labeled.enhancement": "dangerfile.js",
+      "pull_request.labeled(enhancement)": "dangerfile.js",
     }
     const body = {
       action: "labeled",
@@ -193,6 +193,58 @@ describe("for label events", () => {
     }
 
     expect(dangerRunForRules("pull_request", "labeled", body, rules)).toEqual([])
+  })
+
+  it("returns a run for a labeled event with commas in the label name", () => {
+    const rules = {
+      "pull_request.labeled(this,works)": "dangerfile.js",
+    }
+    const body = {
+      action: "labeled",
+      event: "pull_request",
+      label: {
+        name: "this,works",
+      },
+    }
+
+    expect(dangerRunForRules("pull_request", "labeled", body, rules)).toEqual([
+      {
+        action: "labeled",
+        branch: "master",
+        dangerfilePath: "dangerfile.js",
+        dslType: RunType.pr,
+        event: "pull_request",
+        feedback: RunFeedback.commentable,
+        referenceString: "dangerfile.js",
+        repoSlug: undefined,
+      },
+    ])
+  })
+
+  it("supports multiple trigger events with label names", () => {
+    const rules = {
+      "pull_request, pull_request.labeled(this,works), pull_request.unlabeled(question)": "dangerfile.js",
+    }
+    const body = {
+      action: "labeled",
+      event: "pull_request",
+      label: {
+        name: "this,works",
+      },
+    }
+
+    expect(dangerRunForRules("pull_request", "labeled", body, rules)).toEqual([
+      {
+        action: "labeled",
+        branch: "master",
+        dangerfilePath: "dangerfile.js",
+        dslType: RunType.pr,
+        event: "pull_request",
+        feedback: RunFeedback.commentable,
+        referenceString: "dangerfile.js",
+        repoSlug: undefined,
+      },
+    ])
   })
 })
 

--- a/source/danger/_tests/_danger_run.test.ts
+++ b/source/danger/_tests/_danger_run.test.ts
@@ -153,6 +153,49 @@ describe("for PRs", () => {
   })
 })
 
+describe("for label events", () => {
+  it("returns a run for a labeled event with a matching label name", () => {
+    const rules = {
+      "pull_request.labeled.question": "dangerfile.js",
+    }
+    const body = {
+      action: "labeled",
+      event: "pull_request",
+      label: {
+        name: "question",
+      },
+    }
+
+    expect(dangerRunForRules("pull_request", "labeled", body, rules)).toEqual([
+      {
+        action: "labeled",
+        branch: "master",
+        dangerfilePath: "dangerfile.js",
+        dslType: RunType.pr,
+        event: "pull_request",
+        feedback: RunFeedback.commentable,
+        referenceString: "dangerfile.js",
+        repoSlug: undefined,
+      },
+    ])
+  })
+
+  it("returns null when no label names match", () => {
+    const rules = {
+      "pull_request.labeled.enhancement": "dangerfile.js",
+    }
+    const body = {
+      action: "labeled",
+      event: "pull_request",
+      label: {
+        name: "question",
+      },
+    }
+
+    expect(dangerRunForRules("pull_request", "labeled", body, rules)).toEqual([])
+  })
+})
+
 describe("dangerRepresentationforPath", () => {
   it("returns just the path with master and no repo with just a path", () => {
     const path = "dangerfile.ts"

--- a/source/danger/_tests/_danger_run.test.ts
+++ b/source/danger/_tests/_danger_run.test.ts
@@ -1,9 +1,11 @@
 import { dangerRepresentationForPath, dangerRunForRules, dslTypeForEvent, RunFeedback, RunType } from "../danger_run"
 
 describe("for ping", () => {
+  const body = {}
+
   it("returns an action when ping is in the rules", () => {
     const rules = { ping: "dangerfile.js" }
-    expect(dangerRunForRules("ping", null, rules)).toEqual([
+    expect(dangerRunForRules("ping", null, body, rules)).toEqual([
       {
         action: null,
         branch: "master",
@@ -19,14 +21,16 @@ describe("for ping", () => {
 
   it("returns nothing when ping is not in the rules", () => {
     const rules = {}
-    expect(dangerRunForRules("ping", null, rules)).toEqual([])
+    expect(dangerRunForRules("ping", null, body, rules)).toEqual([])
   })
 })
 
 describe("for PRs", () => {
+  const body = {}
+
   it("returns a PR when PR is in the rules", () => {
     const rules = { pull_request: "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "created", rules)).toEqual([
+    expect(dangerRunForRules("pull_request", "created", body, rules)).toEqual([
       {
         action: "created",
         branch: "master",
@@ -42,7 +46,7 @@ describe("for PRs", () => {
 
   it("returns two events when rule contains two files", () => {
     const rules = { pull_request: ["dangerfile.js", "anotherdangerfile.ts"] }
-    expect(dangerRunForRules("pull_request", "created", rules).map(r => r.dangerfilePath)).toEqual([
+    expect(dangerRunForRules("pull_request", "created", body, rules).map(r => r.dangerfilePath)).toEqual([
       "dangerfile.js",
       "anotherdangerfile.ts",
     ])
@@ -51,7 +55,7 @@ describe("for PRs", () => {
   // Same semantics
   it("returns a PR run when all sub events are globbed in the rules", () => {
     const rules = { "pull_request.*": "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "updated", rules)).toEqual([
+    expect(dangerRunForRules("pull_request", "updated", body, rules)).toEqual([
       {
         action: "updated",
         branch: "master",
@@ -67,12 +71,12 @@ describe("for PRs", () => {
 
   it("returns null when you only ask for a specific action", () => {
     const rules = { "pull_request.created": "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "updated", rules)).toEqual([])
+    expect(dangerRunForRules("pull_request", "updated", body, rules)).toEqual([])
   })
 
   it("returns a PR run when event contains action suffix", () => {
     const rules = { "pull_request.deleted": "dangerfile.js" }
-    expect(dangerRunForRules("pull_request", "deleted", rules)).toEqual([
+    expect(dangerRunForRules("pull_request", "deleted", body, rules)).toEqual([
       {
         action: "deleted",
         branch: "master",
@@ -93,14 +97,14 @@ describe("for PRs", () => {
       "pull_request.*": "dangerfile.js",
       "pull_request.updated": "dangerfile.js",
     }
-    expect(dangerRunForRules("pull_request", "updated", rules).length).toEqual(3)
+    expect(dangerRunForRules("pull_request", "updated", body, rules).length).toEqual(3)
   })
 
   it("returns a PR when multiple rules are declared inline", () => {
     const rules = {
       "issue, pull_request": "dangerfile.js",
     }
-    expect(dangerRunForRules("pull_request", "created", rules)).toEqual([
+    expect(dangerRunForRules("pull_request", "created", body, rules)).toEqual([
       {
         action: "created",
         branch: "master",
@@ -118,7 +122,7 @@ describe("for PRs", () => {
     const rules = {
       "issue.created, pull_request.closed": "dangerfile.js",
     }
-    expect(dangerRunForRules("pull_request", "created", rules)).toEqual([])
+    expect(dangerRunForRules("pull_request", "created", body, rules)).toEqual([])
   })
 
   it("returns a PR when PR is in the rules and there are multi inline rules", () => {
@@ -126,7 +130,7 @@ describe("for PRs", () => {
       "issue.created, issue.closed": "dangerfile.js",
       pull_request: "dangerfile.js",
     }
-    expect(dangerRunForRules("pull_request", "created", rules)).toEqual([
+    expect(dangerRunForRules("pull_request", "created", body, rules)).toEqual([
       {
         action: "created",
         branch: "master",
@@ -145,7 +149,7 @@ describe("for PRs", () => {
       issue: "dangerfile.js",
       "pull_request, pull_request.*, pull_request.updated": "dangerfile.js",
     }
-    expect(dangerRunForRules("pull_request", "updated", rules).length).toEqual(1)
+    expect(dangerRunForRules("pull_request", "updated", body, rules).length).toEqual(1)
   })
 })
 

--- a/source/danger/danger_run.ts
+++ b/source/danger/danger_run.ts
@@ -36,6 +36,7 @@ export interface DangerRun extends RepresentationForURL {
 export const dangerRunForRules = (
   event: string,
   action: string | null,
+  requestBody: any,
   rule: RunnerRuleset | undefined | null
 ): DangerRun[] => {
   // tslint:disable-line
@@ -48,10 +49,16 @@ export const dangerRunForRules = (
   const globsKey = event + ".*"
   const dotActionKey = event + "." + action
 
+  let allKeys = [directKey, globsKey, dotActionKey]
+
+  if (action === "labeled" || action === "unlabeled") {
+    const labelName: string = requestBody.label.name
+    allKeys.push(event + "." + action + "." + labelName)
+  }
+
   const arraydVersions = Object.keys(rule)
     .filter(key => {
       const indvRules = key.split(",").map(i => i.trim())
-      const allKeys = [directKey, globsKey, dotActionKey]
       return allKeys.some(key => indvRules.includes(key))
     })
     .map(key => {

--- a/source/danger/danger_run.ts
+++ b/source/danger/danger_run.ts
@@ -49,7 +49,7 @@ export const dangerRunForRules = (
   const globsKey = event + ".*"
   const dotActionKey = event + "." + action
 
-  let allKeys = [directKey, globsKey, dotActionKey]
+  const allKeys = [directKey, globsKey, dotActionKey]
 
   if (action === "labeled" || action === "unlabeled") {
     const labelName: string = requestBody.label.name

--- a/source/db/mongo.ts
+++ b/source/db/mongo.ts
@@ -46,6 +46,7 @@ const prepareToSave = (installation: Partial<GitHubInstallation>) => {
   userInput.forEach(i => {
     if (amendedInstallation[i]) {
       amendedInstallation[i] = removeDots(amendedInstallation[i])
+      amendedInstallation[i] = removeDollars(amendedInstallation[i])
     }
   })
   return installation
@@ -56,6 +57,7 @@ const convertDBRepresentationToModel = (installation: GitHubInstallation) => {
   userInput.forEach(i => {
     if (amendedInstallation[i]) {
       amendedInstallation[i] = bringBackDots(amendedInstallation[i])
+      amendedInstallation[i] = bringBackDollars(amendedInstallation[i])
     }
   })
   return installation
@@ -64,6 +66,10 @@ const convertDBRepresentationToModel = (installation: GitHubInstallation) => {
 // We can't store keys which have a dot in them, and basically all settings JSON has this.
 const removeDots = (obj: object) => transformKeys(obj, ".", "___")
 const bringBackDots = (obj: object) => transformKeys(obj, "___", ".")
+
+// We cant store keys with a dollar sign and they may be present in label names.
+const removeDollars = (obj: object) => transformKeys(obj, "$", "____")
+const bringBackDollars = (obj: object) => transformKeys(obj, "____", "$")
 
 const transformKeys = (obj: any, before: string, after: string) =>
   Object.keys(obj).reduce(

--- a/source/github/events/_tests/_github_runner-prs.test.ts
+++ b/source/github/events/_tests/_github_runner-prs.test.ts
@@ -34,7 +34,7 @@ it("runs an Dangerfile for a PR with a local", async () => {
   const body = fixture("pull_request_opened.json")
   const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
-  const run = dangerRunForRules("pull_request", "opened", {
+  const run = dangerRunForRules("pull_request", "opened", body, {
     pull_request: "dangerfile.pr",
   })[0]
 
@@ -58,7 +58,7 @@ describe("when someone edits the dangerfile", () => {
     const body = fixture("pull_request_opened.json")
     const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
-    const run = dangerRunForRules("pull_request", "opened", {
+    const run = dangerRunForRules("pull_request", "opened", body, {
       pull_request: "dangerfile.no.access.pr",
     })[0]
 
@@ -75,7 +75,7 @@ describe("when someone edits the dangerfile", () => {
     const body = fixture("pull_request_opened.json")
     const settings = await setupForRequest({ body, headers: { "X-GitHub-Delivery": "12345" } } as any, {})
 
-    const run = dangerRunForRules("pull_request", "opened", {
+    const run = dangerRunForRules("pull_request", "opened", body, {
       pull_request: "dangerfile.no.access.pr",
     })[0]
 

--- a/source/github/events/_tests/_github_runner-runs.test.ts
+++ b/source/github/events/_tests/_github_runner-runs.test.ts
@@ -33,6 +33,8 @@ const getSettings = (overwrites: Partial<GitHubRunSettings>) => ({
   ...overwrites,
 })
 
+const body = {}
+
 it("handles a platform only run", () => {
   const installation = generateInstallation({
     iID: 12,
@@ -44,7 +46,7 @@ it("handles a platform only run", () => {
 
   const settings = getSettings({ repoSpecificRules: {} })
 
-  const runs = runsForEvent("pull_request", "created", installation, settings)
+  const runs = runsForEvent("pull_request", "created", body, installation, settings)
   expect(runs).toEqual([
     {
       action: "created",
@@ -70,7 +72,7 @@ it("gets the expected runs for platform + repo rules", () => {
 
   const settings = getSettings({})
 
-  const runs = runsForEvent("pull_request", "created", installation, settings)
+  const runs = runsForEvent("pull_request", "created", body, installation, settings)
   expect(runs).toEqual([
     {
       action: "created",
@@ -118,7 +120,7 @@ it("gets the expected runs for platform", () => {
     repoName: repo.fullName,
   })
 
-  const runs = runsForEvent("issues", "created", installation, settings)
+  const runs = runsForEvent("issues", "created", body, installation, settings)
   expect(runs).toEqual([
     {
       action: "created",

--- a/source/github/events/github_runner.ts
+++ b/source/github/events/github_runner.ts
@@ -121,7 +121,7 @@ export const githubDangerRunner = async (event: string, req: express.Request, re
     return
   }
 
-  const runs = runsForEvent(event, action, installation, settings)
+  const runs = runsForEvent(event, action, req.body, installation, settings)
   const name = action ? `${event}.${action}` : event
   if (runs.length) {
     logger.info("")
@@ -137,11 +137,12 @@ export const githubDangerRunner = async (event: string, req: express.Request, re
 export function runsForEvent(
   event: string,
   action: string | null,
+  body: any,
   installation: GitHubInstallation,
   settings: GitHubRunSettings
 ) {
-  const installationRun = dangerRunForRules(event, action, installation.rules)
-  const repoRun = dangerRunForRules(event, action, settings.repoSpecificRules)
+  const installationRun = dangerRunForRules(event, action, body, installation.rules)
+  const repoRun = dangerRunForRules(event, action, body, settings.repoSpecificRules)
   return [...installationRun, ...repoRun].filter(r => !!r) as DangerRun[]
 }
 

--- a/source/github/events/handlers/_tests/events.test.ts
+++ b/source/github/events/handlers/_tests/events.test.ts
@@ -42,7 +42,7 @@ it("runs an Dangerfile for an issue with a local", async () => {
   const settings = await setupForRequest(req, {})
   expect(settings.commentableID).toBeTruthy()
 
-  const run = dangerRunForRules("issue_comment", "created", {
+  const run = dangerRunForRules("issue_comment", "created", body, {
     issue_comment: "dangerfile.issue",
   })[0]
 
@@ -60,7 +60,7 @@ it("adds github util functions and apis to the DSL for non-PR events", async () 
 
   const dangerfileForRun = "warn(danger.github.api)"
   mockGHContents.mockImplementationOnce(() => Promise.resolve(dangerfileForRun))
-  const run = dangerRunForRules("issue_comment", "created", {
+  const run = dangerRunForRules("issue_comment", "created", body, {
     issue_comment: "warn_with_api",
   })[0]
 
@@ -78,7 +78,7 @@ it("adds github util functions and apis to the DSL for non-PR events", async () 
   // Pass in the installation ID to warn
   const dangerfileForRun = "module.exports.default = (deets) => { warn(deets.installation.id) }"
   mockGHContents.mockImplementationOnce(() => Promise.resolve(dangerfileForRun))
-  const run = dangerRunForRules("issue_comment", "created", {
+  const run = dangerRunForRules("issue_comment", "created", body, {
     issue_comment: "warn_with_api",
   })[0]
 
@@ -94,7 +94,7 @@ it("can handle a db returning nil for the repo with an Dangerfile for an issue w
   const settings = await setupForRequest(req, {})
   expect(settings.commentableID).toBeTruthy()
 
-  const run = dangerRunForRules("issue_comment", "created", {
+  const run = dangerRunForRules("issue_comment", "created", body, {
     issue_comment: "dangerfile.issue",
   })[0]
 


### PR DESCRIPTION
Resolves #259 

This is pointed at `enhancement/multi-rule-trigger` for now because it builds on its commits.

This allows users to specify a label name in a labeled or unlabeled action:
```
rules: {
   "pull_request.labeled.question": "dangerfile.js"
}
```

Things to note:
- I've encoded the $ character with 4 underscores because it's not mongo friendly and may be used in label names.
- Dots in label names were already handled

This is WIP because while writing it I noticed if a label name contains a comma for multi inline rules (#259) it won't split properly 😄 
