### PR TITLE
Adds a new way to determine which type of environment we're currently running in

### DIFF
--- a/source/danger/append_peril.ts
+++ b/source/danger/append_peril.ts
@@ -5,7 +5,8 @@ import GitHubUtils from "danger/distribution/platforms/github/GitHubUtils"
 import { DangerContext } from "danger/distribution/runner/Dangerfile"
 
 import { getTemporaryAccessTokenForInstallation } from "../api/github"
-import { isSelfHosted } from "../db/getDB"
+import { runtimeEnvironment } from "../db/getDB"
+import { RuntimeEnvironment } from "../db/runtimeEnv"
 import { PerilRunnerBootstrapJSON } from "../runner/triggerSandboxRun"
 import { generateTaskSchedulerForInstallation } from "../tasks/scheduleTask"
 import { InstallationToRun } from "./danger_runner"
@@ -76,12 +77,7 @@ export const perilObjectForInstallation = (
     installation.settings.env_vars &&
     Object.assign({}, ...installation.settings.env_vars.map(k => ({ [k]: environment[k] })))
 
-  let env = {}
-  if (isSelfHosted) {
-    env = envVarsForSelfHosted()
-  } else {
-    env = environment
-  }
+  const env = runtimeEnvironment === RuntimeEnvironment.Standalone ? envVarsForSelfHosted() : environment
 
   return {
     env,

--- a/source/db/__mocks__/getDB.ts
+++ b/source/db/__mocks__/getDB.ts
@@ -1,4 +1,5 @@
 import { DatabaseAdaptor, GitHubInstallation } from ".."
+import { RuntimeEnvironment } from "../runtimeEnv"
 
 // Caches per test file, so you can import it and check from the import
 // If this is an issue, don't use this mock :D
@@ -54,4 +55,4 @@ export const getDB = (): MockDB => {
   return perTestFileMock
 }
 
-export const isSelfHosted = false
+export const runtimeEnv = RuntimeEnvironment.Standalone

--- a/source/db/getDB.ts
+++ b/source/db/getDB.ts
@@ -2,10 +2,21 @@ import { jsonDatabase } from "./json"
 import { mongoDatabase } from "./mongo"
 
 import { DatabaseAdaptor } from "."
+import { RuntimeEnvironment } from "./runtimeEnv"
 
 const isJest = typeof jest !== "undefined"
 
-export const isSelfHosted = process.env.DATABASE_JSON_FILE !== null
+const hasJSONDef = !!process.env.DATABASE_JSON_FILE
+const hasPerilAPIURL = !!process.env.PUBLIC_API_ROOT_URL
+const hasHyperEnv = !!process.env.x_hyper_content_sha256
+
+export const runtimeEnvironment = hasJSONDef
+  ? RuntimeEnvironment.Standalone
+  : hasPerilAPIURL
+    ? RuntimeEnvironment.Peril
+    : hasHyperEnv
+      ? RuntimeEnvironment.Runner
+      : RuntimeEnvironment.Unknown
 
 const getDatabaseForEnv = (env: any): DatabaseAdaptor | null => {
   if (env.DATABASE_JSON_FILE || isJest) {

--- a/source/db/runtimeEnv.ts
+++ b/source/db/runtimeEnv.ts
@@ -1,0 +1,10 @@
+export enum RuntimeEnvironment {
+  /** On Heroku */
+  Standalone,
+  /** Peril prod/staging */
+  Peril,
+  /** Inside the peril runner in a docker */
+  Runner,
+  /** dunno */
+  Unknown,
+}

--- a/source/github/events/handlers/_tests/_events-create-fixture.test.ts
+++ b/source/github/events/handlers/_tests/_events-create-fixture.test.ts
@@ -28,7 +28,7 @@ jest.mock("../../../../runner/hyper-api", () => ({
 const apiFixtures = resolve(__dirname, "../../_tests/fixtures")
 const fixture = (file: string) => JSON.parse(readFileSync(resolve(apiFixtures, file), "utf8"))
 
-it.only("passes the right args to the hyper functions", async () => {
+it("passes the right args to the hyper functions", async () => {
   mockDB.getInstallation.mockReturnValue({ iID: "123", repos: {}, envVars: { hello: "world" } })
 
   const body = fixture("issue_comment_created.json")

--- a/source/github/events/handlers/_tests/_events.test.ts
+++ b/source/github/events/handlers/_tests/_events.test.ts
@@ -5,7 +5,7 @@ jest.mock("../../../../db/getDB", () => ({
     getInstallation: () => Promise.resolve({ repos: mockGetRepo }),
   }),
   // Make sure it uses the inline Danger runner
-  isSelfHosted: true,
+  runtimeEnvironment: 0,
 }))
 
 const mockGHContents = jest.fn((_, __, path) => {


### PR DESCRIPTION
A bunch of my recent mistakes revolve around forgetting that there are *3* environments in which Peril is running:

* Someone self-hosting for their org
* Me, on peril staging
* Me, on a run from peril staging in docker

Each has very different setups in terms of data access, env vars and general rights. This gives one single way to represent those environments.