### PR TITLE
Adds docs for Checks API permissions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,9 @@
 
 ## 2018 - May 17
 
-- Merged in Danger JS changes for multiple execution runs, and checks instead of comments - orta
+[BREAKING CHANGES]
+
+- Merged in Danger JS changes for multiple execution runs, and checks instead of comments you will need Checks API permissions, see the updated setup docs - orta
 
 ## 2018 - May 13
 

--- a/docs/setup_for_org.md
+++ b/docs/setup_for_org.md
@@ -34,6 +34,7 @@ you webhooks. It can be any string, so long as it's the same in the heroku setup
 
 With respect to **permissions**, my recommendations are:
 
+- `Checks: Read & Write` - _Peril comments on PRs via the Checks API_
 - `Repo Metadata: Read` - _no option on this one_
 - `Repository contents: Read` - _Let Peril read your code_
 - `Issues: Read & Write` - _let Peril see/amend new issues_


### PR DESCRIPTION
Since #278 (and https://github.com/danger/danger-js/pull/594), Danger has used the Checks API, which needs permissions from GitHub. This PR updates the docs and makes a note in the Changelog. See discussion in #328.