### PR TITLE
Fix for platformResultsPreMapper/concat problem

### DIFF
--- a/source/danger/peril_platform.ts
+++ b/source/danger/peril_platform.ts
@@ -34,14 +34,14 @@ export const getPerilPlatformForDSL = (type: RunType, github: GitHubType | null,
     }
 
     const nullFunc: any = () => ""
+    const platformResultsPreMapper = github
+      ? !SKIP_CHECKS_SUPPORT && github.platformResultsPreMapper && github.platformResultsPreMapper.bind(github)
+      : nullFunc
     const platform: Platform = {
       name: "Peril",
       getFileContents: github ? github.getFileContents.bind(github) : nullFunc,
       // Checks Support
-      platformResultsPreMapper: () =>
-        github
-          ? !SKIP_CHECKS_SUPPORT && github.platformResultsPreMapper && github.platformResultsPreMapper.bind(github)
-          : nullFunc,
+      platformResultsPreMapper,
 
       // deprecated, and not used to my knowledge
       handlePostingResults: () =>


### PR DESCRIPTION
So it took looking at the Danger and Peril codebases side-by-side to realize that we've got a subtle type bug. The `Platform` type expects an optional `platformResultsPreMapper`, but Peril was setting that attribute to be a function that _returns_ an optional function. The fix was to move the tertiary expression outside of the `platform` const definition, to run that check _before_ creating the `Platform` object (instead of running the check when the `platformResultsPreMapper` function is called, returning a function where pre-mapper results are expected to be returned).

I've tested and verified this works: https://github.com/ashfurrow/test-repo/issues/13

Fixes #351. Fixes https://github.com/ashfurrow/peril-settings/issues/8.