### PR TITLE
Reshuffles the routing around in Peril

### DIFF
--- a/source/plugins/installationLifeCycle.ts
+++ b/source/plugins/installationLifeCycle.ts
@@ -5,30 +5,24 @@ import { RootObject as InstallationCreated } from "../github/events/types/integr
 import logger from "../logger"
 
 export const installationLifeCycle = (event: string, req: express.Request, res: express.Response, ___: any) => {
-  if (event !== "installation") {
-    return false
+  if (event === "installation") {
+    const request = req.body as InstallationCreated
+    const action = request.action
+    const installation = request.installation
+
+    // Create a db entry for any new installation
+    if (action === "created") {
+      logger.info("")
+      logger.info(`## Creating new installation for ${request.installation.account.login}`)
+      createInstallation(installation, req, res)
+    }
+
+    // Delete any integrations that have uninstalled Peril :wave:
+    if (action === "deleted") {
+      logger.info("")
+      logger.info(`## Deleting installation ${installation.id}`)
+      const db = getDB()
+      db.deleteInstallation(installation.id)
+    }
   }
-
-  const request = req.body as InstallationCreated
-  const action = request.action
-  const installation = request.installation
-
-  // Create a db entry for any new installation
-  if (action === "created") {
-    logger.info("")
-    logger.info(`## Creating new installation for ${request.installation.account.login}`)
-    createInstallation(installation, req, res)
-    return true
-  }
-
-  // Delete any integrations that have uninstalled Peril :wave:
-  if (action === "deleted") {
-    logger.info("")
-    logger.info(`## Deleting installation ${installation.id}`)
-    const db = getDB()
-    db.deleteInstallation(installation.id)
-    return true
-  }
-
-  return false
 }


### PR DESCRIPTION
With the intention being to block the runtime from having access to installation webhooks

re: #362 