### PR TITLE
Ensure a proper random name is generated for each source

### DIFF
--- a/source/danger/danger_runner.ts
+++ b/source/danger/danger_runner.ts
@@ -60,8 +60,9 @@ export async function runDangerForInstallation(
 
   const exec = await executorForInstallation(platform, vm2)
 
-  const randomName = Math.random().toString(36)
-  const localDangerfilePaths = references.map(ref => path.resolve("./" + "danger-" + randomName + path.extname(ref)))
+  const localDangerfilePaths = references.map(ref =>
+    path.resolve("./" + "danger-" + Math.random().toString(36) + path.extname(ref))
+  )
 
   // Allow custom peril funcs to come from the task/scheduler DSL
   if (runtimeEnvironment === RuntimeEnvironment.Standalone) {


### PR DESCRIPTION
## The problem

Danger requires filenames to be different for each script as it uses a comparison based algorithm to identify the index of the script to run.

https://github.com/danger/danger-js/blob/99705705e3715b4c43fb4e82c9b8783c40d0d522/source/runner/runners/inline.ts#L87-L89

The code would use the same random name for all files, effectively running only the 1st one multiple times.

## The solution

generate a random string for each step of the iteration