### PR TITLE
Fixes multiple task repition bug

### DIFF
--- a/source/tasks/startTaskScheduler.ts
+++ b/source/tasks/startTaskScheduler.ts
@@ -110,7 +110,7 @@ export const runTaskForInstallation = async (installation: GitHubInstallation, t
   // Let tasks also be an array if you want, sure, why not?
   const dangerfiles = Array.isArray(taskDangerfiles) ? taskDangerfiles : [taskDangerfiles]
   for (const dangerfile of dangerfiles) {
-    const results = await runTask(task, installation, dangerfiles, data)
+    const results = await runTask(dangerfile, installation, dangerfiles, data)
     // There aren't results when it's process separated
     if (results) {
       if (!results.fails.length) {


### PR DESCRIPTION
I'm not 100% sure about this bug fix, but we've been seeing this problem at Artsy where RFC tasks get run multiple times where configured in an array:

https://github.com/artsy/peril-settings/blob/36ccb57d6aea1ffd88fbb93cce8f9429fcc75724/peril.settings.json#L43

It looks like it just runs the first task over and again for each element in that array. I _think_ this PR fixes that, but I didn't see a test to be sure. 