### PR TITLE
Clean up circle config, add deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
   #  The Peril web server
   api:
     executor:
-      node:
-        dir: api
+      name: node
+      dir: api
 
     steps:
       - yarn-install:
@@ -49,8 +49,8 @@ jobs:
   #  The Peril admin dashboard
   dashboard:
     executor:
-      node:
-        dir: dashboard
+      name: node
+      dir: dashboard
 
     steps:
       - yarn-install:
@@ -60,8 +60,8 @@ jobs:
   #  The Peril public front-end
   web:
     executor:
-      node:
-        dir: web
+      name: node
+      dir: web
 
     steps:
       - yarn-install:
@@ -71,8 +71,8 @@ jobs:
       
   deploy:
     executor:
-      node:
-        dir: ''
+      name: node
+      dir: ''
     steps:
       - yarn-install:
           cache-key: all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,91 +1,95 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
-version: 2
-jobs:
-  #  The Peril web server
-  api:
+version: 2.1
+
+executors:
+  parameters:
+    dir:
+      description: The working directory to use
+      type: string
+  node:
     docker:
       - image: circleci/node:10
-
-    working_directory: ~/repo/api
-
+    working_directory: ~/repo/<< parameters.dir >>
+    
+commands:
+  yarn-install:
+    description: A command that handles installing and caching npm packages
+    parameters:
+      cache-key:
+        description: String to differentiate caches
+        type: string
     steps:
       - checkout:
-          path: ~/repo
-
+            path: ~/repo
       - restore_cache:
           keys:
-            - v1-api-dependencies-{{ checksum "package.json" }}
+            - v1-<< parameters.cache-key >>-dependencies-{{ checksum "package.json" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-api-dependencies-
-
+            - v1-<< parameters.cache-key >>-dependencies-
       - run: yarn install
-
       - save_cache:
           paths:
             - node_modules
-          key: v1-api-dependencies-{{ checksum "package.json" }}
+          key: v1-<< parameters.cache-key >>-dependencies-{{ checksum "package.json" }}
+    
+
+jobs:
+  #  The Peril web server
+  api:
+    executor:
+      node:
+        dir: api
+
+    steps:
+      - yarn-install:
+          cache-key: api
       - run: yarn jest --max-workers=2
 
   #  The Peril admin dashboard
   dashboard:
-    docker:
-      - image: circleci/node:10
-
-    working_directory: ~/repo/dashboard
+    executor:
+      node:
+        dir: dashboard
 
     steps:
-      - checkout:
-          path: ~/repo
-
-      - restore_cache:
-          keys:
-            - v1-dash-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dash-dependencies-
-
-      - run: yarn install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-dash-dependencies-{{ checksum "package.json" }}
+      - yarn-install:
+          cache-key: dash
       - run: yarn build
 
   #  The Peril public front-end
   web:
-    docker:
-      - image: circleci/node:10
-
-    working_directory: ~/repo/web
+    executor:
+      node:
+        dir: web
 
     steps:
-      - checkout:
-          path: ~/repo
-
-      - restore_cache:
-          keys:
-            - v1-web-dependencies-{{ checksum "package.json" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-web-dependencies-
-
-      - run: yarn install
-
-      - save_cache:
-          paths:
-            - node_modules
-          key: v1-web-dependencies-{{ checksum "package.json" }}
+      - yarn-install:
+          cache-key: web
       - run: yarn build
       - run: yarn jest  --max-workers=2
+      
+   deploy:
+     executor:
+       node:
+         dir: ''
+     steps:
+       - yarn-install:
+           cache-key: all
+       - run: echo "deploy here..."
+       
 
 workflows:
-  version: 2
-  api:
+  build:
     jobs:
       - api
-  dashboard:
-    jobs:
       - dashboard
-  web:
-    jobs:
       - web
+      - deploy:
+          filters:
+            branches:
+              only: master
+          requires:
+            - api
+            - dashboard
+            - web

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
+
 version: 2.1
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,11 @@
 version: 2.1
 
 executors:
-  parameters:
-    dir:
-      description: The working directory to use
-      type: string
   node:
+    parameters:
+      dir:
+        description: The working directory to use
+        type: string
     docker:
       - image: circleci/node:10
     working_directory: ~/repo/<< parameters.dir >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,14 +69,14 @@ jobs:
       - run: yarn build
       - run: yarn jest  --max-workers=2
       
-   deploy:
-     executor:
-       node:
-         dir: ''
-     steps:
-       - yarn-install:
-           cache-key: all
-       - run: echo "deploy here..."
+  deploy:
+    executor:
+      node:
+        dir: ''
+    steps:
+      - yarn-install:
+          cache-key: all
+      - run: echo "deploy here..."
        
 
 workflows:


### PR DESCRIPTION
This moves peril over to using circleci 2.1. 

I've done a few things here:

- added an [executor](https://circleci.com/docs/2.0/configuration-reference/#executors-requires-version-21) which encapsulates the common node runtime and working directory logic
- added a [command](https://circleci.com/docs/2.0/configuration-reference/#commands-requires-version-21) to remove duplication of caching/installing packages
- added a deploy job
- cleaned up the workflow to work well with a deploy step
