### PR TITLE
Fix 'disable_github_check' setting

### DIFF
--- a/api/source/db/_tests/__snapshots__/_json.test.ts.snap
+++ b/api/source/db/_tests/__snapshots__/_json.test.ts.snap
@@ -20,6 +20,7 @@ Object {
   },
   "scheduler": Object {},
   "settings": Object {
+    "disable_github_check": false,
     "env_vars": Array [],
     "ignored_repos": Array [],
     "modules": Array [],

--- a/api/source/db/json.ts
+++ b/api/source/db/json.ts
@@ -106,6 +106,7 @@ export const partialInstallationToInstallation = (
     env_vars: (partial.settings && partial.settings.env_vars) || [],
     ignored_repos: (partial.settings && partial.settings.ignored_repos) || [],
     modules: (partial.settings && partial.settings.modules) || [],
+    disable_github_check: (partial.settings && partial.settings.disable_github_check) || false,
   },
 })
 


### PR DESCRIPTION
This is a small change to fix https://github.com/danger/peril/issues/421.

Prior to this change, the `disable_github_check` was not having any effect.