### PR TITLE
Add support for running api on Heroku with mono repo

### DIFF
--- a/app.json
+++ b/app.json
@@ -35,9 +35,16 @@
     "PAPERTRAIL_PORT": {
       "description": "Optional: If you want to see logs via papertrail, this is your port.",
       "required": false
+    },
+    "APP_BASE": {
+      "description": "The directory of the application to deploy. You probably don't want to change this.",
+      "value": "api"
     }
   },
   "buildpacks": [
+    {
+      "url": "https://github.com/lstoll/heroku-buildpack-monorepo"
+    },
     {
       "url": "heroku/nodejs"
     }

--- a/docs/setup_for_org.md
+++ b/docs/setup_for_org.md
@@ -4,8 +4,6 @@ This doc is for Peril who want to self-host. I'm using Heroku as the example, bu
 server abstraction, e.g. now.sh (which Peril Staging works with) or anything which can run a server from a Docker
 container.
 
-> Sidenote: This is broken on Heroku since I mono-repo'd, and realistically needs to be ported over to now.sh
-
 > Sidenote: here's a note with [terminology](./terminology.md) as it's a little tricky.
 
 So, you will need to have:


### PR DESCRIPTION
Fixes https://github.com/danger/peril/issues/419

This reintroduces support for running the Peril API on Heroku since it has been moved to a mono repo.

## How to test

### Deploy a new app

Here is the Heroku deploy button pointing at my branch. You should be able to deploy a peril API instance just like before.

[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy?template=https://github.com/jtreanor/peril/tree/heroku-monorepo)

### Updating an existing Heroku app

To update an existing peril Heroku app to use the mono repo, you can follow these steps:

1. Add the build pack: `heroku buildpacks:add -a <app> https://github.com/lstoll/heroku-buildpack-monorepo -i 1`.
2. Add the config variable: `heroku config:set APP_BASE=api`.
3. Trigger a new deploy. Check out latest and run `git push heroku master`.