### PR TITLE
Don't pass GitDSL to handleResults

### DIFF
--- a/api/source/github/events/utils/commenting.ts
+++ b/api/source/github/events/utils/commenting.ts
@@ -25,9 +25,9 @@ export const commentOnResults = async (
   const platform = getPerilPlatformForDSL(dslType, gh, {})
   const exec = executorForInstallation(platform, vm2, installationSettings)
 
-  // TODO: Figure what happens here with `git` as being nully,
-  // for one I think it would mean non-sandbox runs cant use inline?
-  await exec.handleResults(results, {} as any)
+  // Don't pass a git dsl object here since we don't have one
+  // This means inline comments won't work
+  await exec.handleResults(results)
 }
 
 /** Pulls out the main ID for commenting on a PR or Issue */


### PR DESCRIPTION
This fixes https://github.com/danger/peril/issues/436.

By not passing anything to the now option `git` parameter of `handleResults`, posting comments now works without crashing. See https://github.com/danger/danger-js/pull/887 for the Danger changes.

Thanks to @orta for the quick update to Danger in 1e1b12268a543efedc898d83c73ba5e418b777c7.