### PR TITLE
Use full DSL for non-sandboxed PR runs

### DIFF
--- a/api/source/github/events/_tests/_github_runner-prs.test.ts
+++ b/api/source/github/events/_tests/_github_runner-prs.test.ts
@@ -25,7 +25,7 @@ import { runPRRun } from "../handlers/pr"
 const apiFixtures = resolve(__dirname, "fixtures")
 const fixture = (file: string) => JSON.parse(readFileSync(resolve(apiFixtures, file), "utf8"))
 
-jest.mock("../createPRDSL", () => ({ createPRJSONDSL: () => Promise.resolve({}) }))
+jest.mock("../createPRDSL", () => ({ createPRDSL: () => Promise.resolve({}) }))
 
 it("runs a Dangerfile for a PR with a local", async () => {
   mockContents.mockImplementationOnce(() => Promise.resolve("fail('dangerfile')"))

--- a/api/source/github/events/createPRDSL.ts
+++ b/api/source/github/events/createPRDSL.ts
@@ -14,6 +14,11 @@ import { source } from "../../danger/peril_ci_source"
  */
 export const createPRDSL = async (githubAPI: GitHubAPI) => {
   const jsonDSL = await createPRJSONDSL(githubAPI)
+  // Danger JS expects the Github access token to be set on
+  // settings.github.accessToken, so put it there if we have one
+  if (githubAPI.token !== undefined) {
+    jsonDSL.settings.github.accessToken = githubAPI.token
+  }
   return await jsonToDSL(jsonDSL, source)
 }
 

--- a/api/source/github/events/handlers/_tests/__snapshots__/_pr-create-fixture.test.ts.snap
+++ b/api/source/github/events/handlers/_tests/__snapshots__/_pr-create-fixture.test.ts.snap
@@ -12,39 +12,6 @@ Object {
   ],
   "payload": Object {
     "dsl": Object {
-      "git": Object {
-        "JSONDiffForFile": [Function],
-        "JSONPatchForFile": [Function],
-        "commits": Array [
-          Object {
-            "author": Object {
-              "date": "1",
-              "email": "1",
-              "name": "1",
-            },
-            "committer": Object {
-              "date": "1",
-              "email": "1",
-              "name": "1",
-            },
-            "message": "456",
-            "sha": "123",
-            "tree": Object {
-              "sha": "123",
-              "url": "123",
-            },
-            "url": "123",
-          },
-        ],
-        "created_files": Array [],
-        "deleted_files": Array [],
-        "diffForFile": [Function],
-        "fileMatch": [Function],
-        "linesOfCode": [Function],
-        "modified_files": Array [],
-        "structuredDiffForFile": [Function],
-      },
-      "github": Object {},
       "settings": Object {
         "cliArgs": Object {},
         "github": Object {

--- a/api/source/github/events/handlers/_tests/_pr-create-fixture.test.ts
+++ b/api/source/github/events/handlers/_tests/_pr-create-fixture.test.ts
@@ -34,6 +34,8 @@ jest.mock("../../../../danger/peril_platform", () => ({
   getPerilPlatformForDSL: () => mockPlatform,
 }))
 
+jest.mock("../../createPRDSL", () => ({ createPRDSL: () => Promise.resolve({}) }))
+
 const apiFixtures = resolve(__dirname, "../../_tests/fixtures")
 const fixture = (file: string) => JSON.parse(readFileSync(resolve(apiFixtures, file), "utf8"))
 

--- a/api/source/github/events/handlers/_tests/fixtures/PerilRunnerPRBootStrapExample.json
+++ b/api/source/github/events/handlers/_tests/fixtures/PerilRunnerPRBootStrapExample.json
@@ -5,33 +5,6 @@
   },
   "payload": {
     "dsl": {
-      "git": {
-        "modified_files": [],
-        "created_files": [],
-        "deleted_files": [],
-        "commits": [
-          {
-            "sha": "123",
-            "author": {
-              "name": "1",
-              "email": "1",
-              "date": "1"
-            },
-            "committer": {
-              "name": "1",
-              "email": "1",
-              "date": "1"
-            },
-            "message": "456",
-            "tree": {
-              "sha": "123",
-              "url": "123"
-            },
-            "url": "123"
-          }
-        ]
-      },
-      "github": {},
       "settings": {
         "github": {
           "accessToken": "12345",

--- a/api/source/github/events/handlers/pr.ts
+++ b/api/source/github/events/handlers/pr.ts
@@ -2,7 +2,7 @@ import { DangerResults } from "danger/distribution/dsl/DangerResults"
 import { DangerRun, RunType } from "../../../danger/danger_run"
 import { runDangerForInstallation } from "../../../danger/danger_runner"
 import { canUserWriteToRepo, getGitHubFileContents } from "../../lib/github_helpers"
-import { createPRJSONDSL } from "../createPRDSL"
+import { createPRDSL } from "../createPRDSL"
 import { GitHubRunSettings } from "../github_runner"
 import { Pull_request } from "../types/pull_request_updated.types"
 import { githubAPIForCommentable } from "../utils/commenting"
@@ -57,7 +57,7 @@ export const runPRRun = async (
     settings: settings.installationSettings,
   }
 
-  const dangerDSL = await createPRJSONDSL(githubAPI)
+  const dangerDSL = await createPRDSL(githubAPI)
   const results = await runDangerForInstallation(
     eventName,
     contents,


### PR DESCRIPTION
This fixes https://github.com/danger/peril/issues/367.

Currently, the full DSL is not used for non-sandboxed PR runs. This fixes that by calling the existing `createPRDSL` function and providing the GH access token so the API can be authenticated.

This was not a problem for sandboxed runs since `guthub.api` and `github.utils` are recreated in `appendPerilContextToDSL`.

