### PR TITLE
Catches error from missing PR

### DIFF
--- a/api/source/github/events/handlers/pr.ts
+++ b/api/source/github/events/handlers/pr.ts
@@ -1,3 +1,4 @@
+import { DangerDSLType } from "danger/distribution/dsl/DangerDSL"
 import { DangerResults } from "danger/distribution/dsl/DangerResults"
 import { DangerRun, RunType } from "../../../danger/danger_run"
 import { runDangerForInstallation } from "../../../danger/danger_runner"
@@ -57,7 +58,19 @@ export const runPRRun = async (
     settings: settings.installationSettings,
   }
 
-  const dangerDSL = await createPRDSL(githubAPI)
+  let dangerDSL: DangerDSLType
+  try {
+    dangerDSL = await createPRDSL(githubAPI)
+  } catch (error) {
+    const message = `Not running Danger because we could not access the GitHub PR ${error}.`
+    return {
+      fails: [],
+      markdowns: [],
+      warnings: [],
+      messages: [{ message }],
+    }
+  }
+
   const results = await runDangerForInstallation(
     eventName,
     contents,


### PR DESCRIPTION
Fixes #441.

Not sure why a PR would ever come back 404 from GitHub (since GitHub gives Peril the PR number, and they can't be easily deleted), but anyway. [The method ultimately can throw](https://github.com/danger/danger-js/blob/838afd74efdbbbe99dd86cd1757c595423031eb2/source/platforms/GitHub.ts#L47-L51) and this seemed like the best spot to put error-handling. 