### PR TITLE
Fix winston warnings around missing log level

### DIFF
--- a/api/source/api/pr/dsl.ts
+++ b/api/source/api/pr/dsl.ts
@@ -12,7 +12,7 @@ import { githubAPIForCommentable } from "../../github/events/utils/commenting"
 import { PERIL_ORG_INSTALLATION_ID } from "../../globals"
 
 export const prDSLRunner = async (req: express.Request, res: express.Response, _: express.NextFunction) => {
-  winston.log("router", `Received OK`)
+  winston.info("[router] -- Received OK")
 
   const query = req.query
   if (!query.owner) {

--- a/api/source/routing/router.ts
+++ b/api/source/routing/router.ts
@@ -13,7 +13,7 @@ export const githubRouter = (req: Request, res: Response, next: NextFunction) =>
   if (!event) {
     return
   }
-  winston.log("router", `Received ${event}:`)
+  winston.info(`[router] -- Received ${event}:`)
 
   // Creating / Removing installations from the DB
   installationLifeCycle(event, req, res, next)


### PR DESCRIPTION
closes #444 

I noticed a lot of warnings from winston about an invalid log level. Looks like there were just some places where `winston.log` was being called with `router` being the first argument which was being treated as a log level. 