### PR TITLE
Prefix pre_hook bash file with #!/bin/bash

### DIFF
--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,1 +1,2 @@
+#!/bin/bash
 cd api


### PR DESCRIPTION
At the moment autobuilds from docker are failing as below.

```
Executing pre_build hook...
Could not execute hook at 'hooks/pre_build'. Is it missing a #! line?
```

As per dockers [docs](https://docs.docker.com/docker-hub/builds/advanced/) this PR adds the `#!/bin/bash` prefix to the file.