### PR TITLE
Updates Papertrail invocation

### DIFF
--- a/api/source/logger.ts
+++ b/api/source/logger.ts
@@ -8,10 +8,12 @@ import { PAPERTRAIL_PORT, PAPERTRAIL_URL } from "./globals"
 // Optional, adds papertrail to the logging systems
 if (PAPERTRAIL_URL) {
   const transports = winston.transports as any
-  winston.add(transports.Papertrail, {
-    host: PAPERTRAIL_URL,
-    port: parseInt(PAPERTRAIL_PORT as string, 10),
-  })
+  winston.add(
+    new transports.Papertrail({
+      host: PAPERTRAIL_URL,
+      port: parseInt(PAPERTRAIL_PORT as string, 10),
+    })
+  )
 } else {
   // On AWS, or tests, or whatever
   logger.add(


### PR DESCRIPTION
I was hitting an error when trying to deploy a Peril update for @RxSwiftCommunity:

```
remote:        $ node out/scripts/setup-plugins.js
remote:        /tmp/build_f6f92644/node_modules/winston-transport/legacy.js:18
remote:            throw new Error('Invalid transport, must be an object with a log method.');
remote:            ^
remote:
remote:        Error: Invalid transport, must be an object with a log method.
remote:            at new LegacyTransportStream (/tmp/build_f6f92644/node_modules/winston-transport/legacy.js:18:11)
remote:            at DerivedLogger.add (/tmp/build_f6f92644/node_modules/winston/lib/winston/logger.js:345:11)
remote:            at Object.winston.(anonymous function).args [as add] (/tmp/build_f6f92644/node_modules/winston/lib/winston.js:110:68)
remote:            at Object.<anonymous> (/tmp/build_f6f92644/out/logger.js:10:13)
remote:            at Module._compile (internal/modules/cjs/loader.js:778:30)
remote:            at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
remote:            at Module.load (internal/modules/cjs/loader.js:653:32)
remote:            at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
remote:            at Function.Module._load (internal/modules/cjs/loader.js:585:3)
remote:            at Module.require (internal/modules/cjs/loader.js:692:17)
remote:        error Command failed with exit code 1.
remote:        info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
remote:        error Command failed with exit code 1.
remote:        info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
remote:        error Command failed with exit code 1.
remote:        info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
remote:
```

Took a look and found this solution. Everything is working now.