### PR TITLE
fix passing peril instance to inline runner

### DIFF
--- a/api/source/danger/append_peril.ts
+++ b/api/source/danger/append_peril.ts
@@ -95,7 +95,7 @@ export async function appendPerilContextToDSL(
   peril: PerilDSL
 ) {
   // Update the GitHub related details with the new ocktokit generated per installation
-  if (sandbox.danger) {
+  if (sandbox && sandbox.danger) {
     // @ts-ignore - .github is readonly according to the types, but we have to have something here
     sandbox.danger.github = sandbox.danger.github || ({} as any)
     const api = await octokitAPIForPeril(installationID, authToken)
@@ -107,8 +107,7 @@ export async function appendPerilContextToDSL(
       sandbox.danger.github.utils = recreateGitHubUtils(api)
     }
 
-    const anySandbox = sandbox as any
-    anySandbox.peril = peril
+    sandbox.peril = peril
   }
 }
 

--- a/api/source/danger/danger_runner.ts
+++ b/api/source/danger/danger_runner.ts
@@ -62,26 +62,33 @@ export async function runDangerForInstallation(
 
   const exec = await executorForInstallation(platform, vm2, installationRun.settings)
 
-  const localDangerfilePaths = references.map(ref =>
-    path.resolve("./" + perilPrefix + ref)
-  )
+  const localDangerfilePaths = references.map(ref => path.resolve("./" + perilPrefix + ref))
 
   // Allow custom peril funcs to come from the task/scheduler DSL
   if (runtimeEnvironment === RuntimeEnvironment.Standalone) {
     const perilFromRunOrTask = DSL && (DSL as any).peril
     const peril = await perilObjectForInstallation(installationRun, process.env, perilFromRunOrTask)
 
-    const token = gh ? gh.api.token : "";
+    const token = gh ? gh.api.token : ""
 
-    const restoreOriginalModuleLoader = overrideRequire(shouldUseGitHubOverride,
-      customGitHubResolveRequest(token || ""))
+    const restoreOriginalModuleLoader = overrideRequire(
+      shouldUseGitHubOverride,
+      customGitHubResolveRequest(token || "")
+    )
 
-    const results = await runDangerAgainstFileInline(localDangerfilePaths, contents, installationRun, exec, peril, payload)
+    const results = await runDangerAgainstFileInline(
+      localDangerfilePaths,
+      contents,
+      installationRun,
+      exec,
+      peril,
+      payload
+    )
 
     // Restore the original module loader.
-    restoreOriginalModuleLoader();
+    restoreOriginalModuleLoader()
 
-    return results;
+    return results
   } else {
     return await triggerSandboxDangerRun(eventName, type, installationRun, references, payload)
   }
@@ -102,9 +109,9 @@ export async function runDangerAgainstFileInline(
   const context = contextForDanger(dangerDSL)
   const dangerRuntimeEnv = await exec.runner.createDangerfileRuntimeEnvironment(context)
 
-  if (dangerRuntimeEnv.sandbox) {
-    // Mutates runtimeEnv.sandbox
-    await appendPerilContextToDSL(installationRun.iID, undefined, dangerRuntimeEnv.sandbox, peril)
+  if (dangerRuntimeEnv) {
+    // Mutates runtimeEnv
+    await appendPerilContextToDSL(installationRun.iID, undefined, dangerRuntimeEnv, peril)
   }
 
   let results: DangerResults


### PR DESCRIPTION
This tries to fix the logic around appending "Peril context"  before executing inline runner. Current logic checks for `sandbox` property but this is never set, so appending peril context is never executed.

From user perspective - this should fix accessing environment variables via `peril.env.*`, which is currently not working (`peril` objects is just `{}`, it doesn't even have `.env` field)

Closes https://github.com/danger/peril/issues/474