### PR TITLE
Fetch rules from dev branch

### DIFF
--- a/api/source/danger/danger_run.ts
+++ b/api/source/danger/danger_run.ts
@@ -166,12 +166,12 @@ export interface RepresentationForURL {
 /** Takes a DangerfileReferenceString and lets you know where to find it globally */
 export const dangerRepresentationForPath = (value: DangerfileReferenceString): RepresentationForURL => {
   let afterAt = value.includes("@") ? value.split("@")[1] : value
-  afterAt = afterAt.startsWith('/') ? afterAt.substring(1) : afterAt;
+  afterAt = afterAt.startsWith("/") ? afterAt.substring(1) : afterAt
   return {
     branch: value.includes("#") ? value.split("#")[1] : "master",
     dangerfilePath: afterAt.split("#")[0],
     repoSlug: value.includes("@") ? value.split("@")[0] : undefined,
-    referenceString: value,
+    referenceString: value.split("#")[0],
   }
 }
 

--- a/api/source/danger/danger_run.ts
+++ b/api/source/danger/danger_run.ts
@@ -171,7 +171,7 @@ export const dangerRepresentationForPath = (value: DangerfileReferenceString): R
     branch: value.includes("#") ? value.split("#")[1] : "master",
     dangerfilePath: afterAt.split("#")[0],
     repoSlug: value.includes("@") ? value.split("@")[0] : undefined,
-    referenceString: value.split("#")[0],
+    referenceString: value,
   }
 }
 

--- a/api/source/db/json.ts
+++ b/api/source/db/json.ts
@@ -64,10 +64,11 @@ export const jsonDatabase = (dangerFilePath: DangerfileReferenceString): Databas
   getSchedulableInstallationsWithKey: () => Promise.resolve([org]),
 
   setup: async () => {
-    const repo = dangerFilePath.split("@")[0]
-    const path = dangerFilePath.split("@")[1]
+    const ref = dangerFilePath.includes("#") ? dangerFilePath.split("#")[1] : null
+    const repo = dangerFilePath.split("#")[0].split("@")[0]
+    const path = dangerFilePath.split("#")[0].split("@")[1]
 
-    const file = await getGitHubFileContentsWithoutToken(repo, path)
+    const file = await getGitHubFileContentsWithoutToken(repo, path, ref)
 
     if (file === "") {
       throwNoJSONFileFound(dangerFilePath)

--- a/api/source/github/events/handlers/_tests/fixtures/PerilRunnerEventBootStrapExample.json
+++ b/api/source/github/events/handlers/_tests/fixtures/PerilRunnerEventBootStrapExample.json
@@ -243,6 +243,36 @@
         },
         "installation": {
           "id": 23511
+        },
+        "api": {
+          "log": {},
+          "activity": {},
+          "apps": {},
+          "checks": {},
+          "codesOfConduct": {},
+          "emojis": {},
+          "gists": {},
+          "git": {},
+          "gitignore": {},
+          "interactions": {},
+          "issues": {},
+          "licenses": {},
+          "markdown": {},
+          "meta": {},
+          "migrations": {},
+          "oauthAuthorizations": {},
+          "orgs": {},
+          "projects": {},
+          "pulls": {},
+          "rateLimit": {},
+          "reactions": {},
+          "repos": {},
+          "search": {},
+          "teams": {},
+          "users": {},
+          "gitdata": {},
+          "authorization": {},
+          "pullRequests": {}
         }
       },
       "settings": {

--- a/api/source/github/events/handlers/event.ts
+++ b/api/source/github/events/handlers/event.ts
@@ -54,7 +54,7 @@ export const runEventRun = async (
   const results = await runDangerForInstallation(
     eventName,
     contents,
-    runs.map(r => r.referenceString),
+    runs.map(r => r.referenceString.split("#")[0]),
     githubAPI,
     RunType.import,
     installationSettings,

--- a/api/source/github/events/handlers/pr.ts
+++ b/api/source/github/events/handlers/pr.ts
@@ -109,7 +109,7 @@ const validateRuns = async (
 
   for (const run of runs) {
     const neededDangerfileIsLocalRepo = !run.repoSlug
-    const branch = neededDangerfileIsLocalRepo ? dangerfileBranchForPR : null
+    const branch = neededDangerfileIsLocalRepo ? dangerfileBranchForPR : run.branch
 
     // Either it's dictated in the run as an external repo, or we use the most natural repo
     const repoForDangerfileRun = run.repoSlug || dangerfileRepoForPR

--- a/api/source/github/events/handlers/pr.ts
+++ b/api/source/github/events/handlers/pr.ts
@@ -56,7 +56,7 @@ export const runPRRun = async (
 
     const headDangerfile = await getGitHubFileContents(token, repoForDangerfile, run.dangerfilePath, run.branch)
     contents.push(headDangerfile)
-    dangerfileReferences.push(run.referenceString)
+    dangerfileReferences.push(run.referenceString.split("#")[0])
   }
 
   // Everything is :+1:

--- a/api/source/github/lib/github_helpers.ts
+++ b/api/source/github/lib/github_helpers.ts
@@ -59,9 +59,9 @@ export async function getGitHubFileContents(
  * in the environment it will build the appropriate auth.
  * Returns either the contents or an empty string.
  */
-export async function getGitHubFileContentsWithoutToken(repo: string, path: string) {
+export async function getGitHubFileContentsWithoutToken(repo: string, path: string, ref: string | null) {
   // Try see if we can pull it without an access token
-  const file = await getGitHubFileContents(null, repo, path, null, false)
+  const file = await getGitHubFileContents(null, repo, path, ref, false)
   if (file !== "") {
     return file
   }


### PR DESCRIPTION
This PR makes it possible to read settings from branches other than the default repository one. 
This is already supported by Danger using the `#<branch-name>` notation and it looks like some part of the implementation are already in Peril, but it doesn't currently work. 

Basically, these changes just make sure that the selected branch is passed down to Danger. 